### PR TITLE
specific: fix unloading textures (closes #158)

### DIFF
--- a/src/global/vars.h
+++ b/src/global/vars.h
@@ -106,7 +106,6 @@ extern int32_t KeyChange;
 #define IsHardwareRenderer      VAR_U_(0x00463610, int32_t)
 #define IConfig                 VAR_U_(0x0045A23C, int32_t)
 #define RenderSettings          VAR_U_(0x0045A240, uint32_t)
-#define OldRenderSettings       VAR_U_(0x0045E960, uint32_t)
 #define ScanCodeNames           ARRAY_(0x00454A40, char*, [])
 #define OptionMusicVolume       VAR_I_(0x00456334, int32_t, 255)
 #define OptionSoundFXVolume     VAR_I_(0x00456330, int32_t, 165)

--- a/src/specific/frontend.c
+++ b/src/specific/frontend.c
@@ -123,10 +123,6 @@ void S_FinishInventory()
         TempVideoRemove();
     }
     ModeLock = 0;
-    if (RenderSettings != OldRenderSettings) {
-        HWR_DownloadTextures(-1);
-        OldRenderSettings = RenderSettings;
-    }
 }
 
 void S_FadeToBlack()

--- a/src/specific/hwr.c
+++ b/src/specific/hwr.c
@@ -441,12 +441,8 @@ void HWR_DrawSprite(
     if (HWR_TextureLoaded[sprite->tpage]) {
         HWR_EnableTextureMode();
         HWR_SelectTexture(sprite->tpage);
+        HWR_RenderTriangleStrip(vertices, vertex_count);
     }
-
-    // NOTE: original .exe has some additional logic for the case when
-    // the requested texture page was not loaded.
-
-    HWR_RenderTriangleStrip(vertices, vertex_count);
 }
 
 void HWR_Draw2DLine(
@@ -1217,7 +1213,6 @@ void HWR_InitialiseHardware()
     ATI3DCIF_ContextSetState(ATIRenderContext, C3D_ERS_SURF_DRAW_PF, &tmp);
 
     LOG_INFO("    Detected %dk video memory", 4096);
-    // NOTE: skipped dead code related to caching textures
     LOG_INFO("    Complete, hardware ready");
 }
 
@@ -1508,9 +1503,8 @@ void HWR_DrawTexturedTriangle(
     if (HWR_TextureLoaded[tpage]) {
         HWR_EnableTextureMode();
         HWR_SelectTexture(tpage);
+        HWR_RenderTriangleStrip(vertices, vertex_count);
     }
-
-    HWR_RenderTriangleStrip(vertices, vertex_count);
 }
 
 void HWR_DrawTexturedQuad(
@@ -1585,9 +1579,6 @@ void HWR_DrawTexturedQuad(
     }
 
     ATI3DCIF_RenderPrimStrip(vertices, 4);
-
-    // NOTE: original .exe has some additional logic for the case when
-    // the requested texture page was not loaded.
 }
 
 int32_t HWR_ZedClipper(
@@ -1675,20 +1666,12 @@ int32_t HWR_ZedClipper(
 void HWR_InitPolyList()
 {
     HWR_RenderBegin();
-
-    // NOTE: original .exe has some additional logic for rendering
-    // polygons whose textures were not loaded at the draw time.
-
     HWR_LightningCount = 0;
 }
 
 void HWR_OutputPolyList()
 {
     int i;
-
-    // NOTE: original .exe has some additional logic for rendering
-    // polygons whose textures were not loaded at the draw time.
-
     for (i = 0; i < HWR_LightningCount; i++) {
         HWR_RenderLightningSegment(
             HWR_LightningTable[i].x1, HWR_LightningTable[i].y1,

--- a/src/specific/shell.c
+++ b/src/specific/shell.c
@@ -58,7 +58,6 @@ void GameMain()
     S_FrontEndCheck();
     S_ReadUserSettings();
 
-    OldRenderSettings = RenderSettings;
     TempVideoAdjust(2);
     S_DisplayPicture("data\\eidospc");
     S_InitialisePolyList();


### PR DESCRIPTION
The call to `HWR_DownloadTextures` seems to be some artifact from another platform – ATI3DCIF handles changing render settings on the fly just fine, as evidenced by the F3 button working in the OG TombATI.exe. Removing it makes the problem go away with seemingly no side effects. Since we now know the reason why the chunks that were removed in recent decompilation efforts existed, and those routines no longer seem to be necessary, I also removed the NOTE comments.

Also the reported issue demonstrates that it doesn't make sense to keep those prim strip renders out of the `if` blocks, since they're all black anyway, so I pulled them back into the `if` blocks like they were arranged in the original .exe.