### PR TITLE
Text refactor

### DIFF
--- a/src/game/demo.c
+++ b/src/game/demo.c
@@ -62,14 +62,14 @@ int32_t StartDemo()
         SeedRandomDraw(0xD371F947);
         SeedRandomControl(0xD371F947);
 
-        txt = T_Print(0, -16, GF.strings[GS_MISC_DEMO_MODE]);
-        T_FlashText(txt, 1, 20);
-        T_BottomAlign(txt, 1);
-        T_CentreH(txt, 1);
+        txt = Text_Create(0, -16, GF.strings[GS_MISC_DEMO_MODE]);
+        Text_Flash(txt, 1, 20);
+        Text_AlignBottom(txt, 1);
+        Text_CentreH(txt, 1);
 
         GameLoop(1);
 
-        T_RemovePrint(txt);
+        Text_Remove(txt);
 
         *s = start;
         S_FadeToBlack();

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -125,16 +125,16 @@ void LevelStats(int32_t level_num)
     TEXTSTRING *txt;
 
     TempVideoAdjust(GetScreenSizeIdx());
-    T_RemoveAllPrints();
+    Text_RemoveAll();
     AmmoText = NULL;
     FPSText = NULL;
     VersionText = NULL;
 
     // heading
     sprintf(string, "%s", GF.levels[level_num].level_title);
-    txt = T_Print(0, -50, string);
-    T_CentreH(txt, 1);
-    T_CentreV(txt, 1);
+    txt = Text_Create(0, -50, string);
+    Text_CentreH(txt, 1);
+    Text_CentreV(txt, 1);
 
     // time taken
     int32_t seconds = SaveGame.timer / 30;
@@ -149,9 +149,9 @@ void LevelStats(int32_t level_num)
         sprintf(time_str, "%d:%d%d", minutes, seconds / 10, seconds % 10);
     }
     sprintf(string, GF.strings[GS_STATS_TIME_TAKEN_FMT], time_str);
-    txt = T_Print(0, 70, string);
-    T_CentreH(txt, 1);
-    T_CentreV(txt, 1);
+    txt = Text_Create(0, 70, string);
+    Text_CentreH(txt, 1);
+    Text_CentreV(txt, 1);
 
     // secrets
     int32_t secrets_taken = 0;
@@ -166,21 +166,21 @@ void LevelStats(int32_t level_num)
     sprintf(
         string, GF.strings[GS_STATS_SECRETS_FMT], secrets_taken,
         GF.levels[level_num].secrets);
-    txt = T_Print(0, 40, string);
-    T_CentreH(txt, 1);
-    T_CentreV(txt, 1);
+    txt = Text_Create(0, 40, string);
+    Text_CentreH(txt, 1);
+    Text_CentreV(txt, 1);
 
     // pickups
     sprintf(string, GF.strings[GS_STATS_PICKUPS_FMT], SaveGame.pickups);
-    txt = T_Print(0, 10, string);
-    T_CentreH(txt, 1);
-    T_CentreV(txt, 1);
+    txt = Text_Create(0, 10, string);
+    Text_CentreH(txt, 1);
+    Text_CentreV(txt, 1);
 
     // kills
     sprintf(string, GF.strings[GS_STATS_KILLS_FMT], SaveGame.kills);
-    txt = T_Print(0, -20, string);
-    T_CentreH(txt, 1);
-    T_CentreV(txt, 1);
+    txt = Text_Create(0, -20, string);
+    Text_CentreH(txt, 1);
+    Text_CentreV(txt, 1);
 
     // wait till action key release
     while (Input.select || Input.deselect) {
@@ -188,7 +188,7 @@ void LevelStats(int32_t level_num)
         S_InitialisePolyList();
         S_CopyBufferToScreen();
         S_UpdateInput();
-        T_DrawText();
+        Text_Draw();
         S_OutputPolyList();
         S_DumpScreen();
     }
@@ -201,7 +201,7 @@ void LevelStats(int32_t level_num)
         S_InitialisePolyList();
         S_CopyBufferToScreen();
         S_UpdateInput();
-        T_DrawText();
+        Text_Draw();
         S_OutputPolyList();
         S_DumpScreen();
     }
@@ -211,7 +211,7 @@ void LevelStats(int32_t level_num)
         S_InitialisePolyList();
         S_CopyBufferToScreen();
         S_UpdateInput();
-        T_DrawText();
+        Text_Draw();
         S_OutputPolyList();
         S_DumpScreen();
     }

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -120,8 +120,8 @@ int32_t GetRandomDraw()
 
 void LevelStats(int32_t level_num)
 {
-    static char string[100];
-    static char time_str[100];
+    char string[100];
+    char time_str[100];
     TEXTSTRING *txt;
 
     TempVideoAdjust(GetScreenSizeIdx());

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -126,9 +126,6 @@ void LevelStats(int32_t level_num)
 
     TempVideoAdjust(GetScreenSizeIdx());
     Text_RemoveAll();
-    AmmoText = NULL;
-    FPSText = NULL;
-    VersionText = NULL;
 
     // heading
     sprintf(string, "%s", GF.levels[level_num].level_title);

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -53,7 +53,7 @@ int32_t Display_Inventory(int inv_mode)
 
     int32_t pass_mode_open = 0;
     if (AmmoText) {
-        T_RemovePrint(AmmoText);
+        Text_Remove(AmmoText);
         AmmoText = NULL;
     }
 
@@ -238,7 +238,7 @@ int32_t Display_Inventory(int inv_mode)
 
         mn_update_sound_effects();
         Overlay_DrawFPSInfo();
-        T_DrawText();
+        Text_Draw();
         S_OutputPolyList();
 
         InvNFrames = S_DumpScreen();
@@ -606,7 +606,7 @@ int32_t Display_Inventory(int inv_mode)
     RemoveInventoryText();
     S_FinishInventory();
     if (VersionText) {
-        T_RemovePrint(VersionText);
+        Text_Remove(VersionText);
         VersionText = NULL;
     }
 
@@ -728,13 +728,13 @@ void Construct_Inventory()
     InvChosen = 0;
     if (InvMode == INV_TITLE_MODE) {
         InvOptionObjects = TITLE_RING_OBJECTS;
-        VersionText = T_Print(-20, -18, T1MVersion);
-        T_RightAlign(VersionText, 1);
-        T_BottomAlign(VersionText, 1);
-        T_SetScale(VersionText, PHD_ONE * 0.5, PHD_ONE * 0.5);
+        VersionText = Text_Create(-20, -18, T1MVersion);
+        Text_AlignRight(VersionText, 1);
+        Text_AlignBottom(VersionText, 1);
+        Text_SetScale(VersionText, PHD_ONE * 0.5, PHD_ONE * 0.5);
     } else {
         InvOptionObjects = OPTION_RING_OBJECTS;
-        T_RemovePrint(VersionText);
+        Text_Remove(VersionText);
         VersionText = NULL;
     }
 

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -34,6 +34,7 @@ typedef enum {
     PPAGE1 = 64
 } PASS_PAGE;
 
+static TEXTSTRING *VersionText = NULL;
 static int16_t InvNFrames = 2;
 static int16_t CompassNeedle = 0;
 static int16_t CompassSpeed = 0;

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -52,15 +52,6 @@ int32_t Display_Inventory(int inv_mode)
     }
 
     int32_t pass_mode_open = 0;
-    if (AmmoText) {
-        Text_Remove(AmmoText);
-        AmmoText = NULL;
-    }
-    if (FPSText) {
-        Text_Remove(FPSText);
-        FPSText = NULL;
-    }
-
     AlterFOV(T1MConfig.fov_value * PHD_DEGREE);
     InvMode = inv_mode;
 

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -56,6 +56,10 @@ int32_t Display_Inventory(int inv_mode)
         Text_Remove(AmmoText);
         AmmoText = NULL;
     }
+    if (FPSText) {
+        Text_Remove(FPSText);
+        FPSText = NULL;
+    }
 
     AlterFOV(T1MConfig.fov_value * PHD_DEGREE);
     InvMode = inv_mode;

--- a/src/game/invfunc.c
+++ b/src/game/invfunc.c
@@ -45,23 +45,24 @@ void RingIsOpen(RING_INFO *ring)
     if (!InvRingText) {
         switch (ring->type) {
         case RT_MAIN:
-            InvRingText = T_Print(0, 26, GF.strings[GS_HEADING_INVENTORY]);
+            InvRingText = Text_Create(0, 26, GF.strings[GS_HEADING_INVENTORY]);
             break;
 
         case RT_OPTION:
             if (InvMode == INV_DEATH_MODE) {
-                InvRingText = T_Print(0, 26, GF.strings[GS_HEADING_GAME_OVER]);
+                InvRingText =
+                    Text_Create(0, 26, GF.strings[GS_HEADING_GAME_OVER]);
             } else {
-                InvRingText = T_Print(0, 26, GF.strings[GS_HEADING_OPTION]);
+                InvRingText = Text_Create(0, 26, GF.strings[GS_HEADING_OPTION]);
             }
             break;
 
         case RT_KEYS:
-            InvRingText = T_Print(0, 26, GF.strings[GS_HEADING_ITEMS]);
+            InvRingText = Text_Create(0, 26, GF.strings[GS_HEADING_ITEMS]);
             break;
         }
 
-        T_CentreH(InvRingText, 1);
+        Text_CentreH(InvRingText, 1);
     }
 
     if (InvMode == INV_KEYS_MODE || InvMode == INV_DEATH_MODE) {
@@ -71,19 +72,19 @@ void RingIsOpen(RING_INFO *ring)
     if (!InvUpArrow1) {
         if (ring->type == RT_OPTION
             || (ring->type == RT_MAIN && InvKeysObjects)) {
-            InvUpArrow1 = T_Print(20, 28, "[");
-            InvUpArrow2 = T_Print(-20, 28, "[");
-            T_RightAlign(InvUpArrow2, 1);
+            InvUpArrow1 = Text_Create(20, 28, "[");
+            InvUpArrow2 = Text_Create(-20, 28, "[");
+            Text_AlignRight(InvUpArrow2, 1);
         }
     }
 
     if (!InvDownArrow1) {
         if (ring->type == RT_MAIN || ring->type == RT_KEYS) {
-            InvDownArrow1 = T_Print(20, -15, "]");
-            InvDownArrow2 = T_Print(-20, -15, "]");
-            T_BottomAlign(InvDownArrow1, 1);
-            T_BottomAlign(InvDownArrow2, 1);
-            T_RightAlign(InvDownArrow2, 1);
+            InvDownArrow1 = Text_Create(20, -15, "]");
+            InvDownArrow2 = Text_Create(-20, -15, "]");
+            Text_AlignBottom(InvDownArrow1, 1);
+            Text_AlignBottom(InvDownArrow2, 1);
+            Text_AlignRight(InvDownArrow2, 1);
         }
     }
 }
@@ -94,18 +95,18 @@ void RingIsNotOpen(RING_INFO *ring)
         return;
     }
 
-    T_RemovePrint(InvRingText);
+    Text_Remove(InvRingText);
     InvRingText = NULL;
 
     if (InvUpArrow1) {
-        T_RemovePrint(InvUpArrow1);
-        T_RemovePrint(InvUpArrow2);
+        Text_Remove(InvUpArrow1);
+        Text_Remove(InvUpArrow2);
         InvUpArrow1 = NULL;
         InvUpArrow2 = NULL;
     }
     if (InvDownArrow1) {
-        T_RemovePrint(InvDownArrow1);
-        T_RemovePrint(InvDownArrow2);
+        Text_Remove(InvDownArrow1);
+        Text_Remove(InvDownArrow2);
         InvDownArrow1 = NULL;
         InvDownArrow2 = NULL;
     }
@@ -117,65 +118,65 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         switch (inv_item->object_number) {
         case O_PUZZLE_OPTION1:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].puzzle1);
+                Text_Create(0, -16, GF.levels[CurrentLevel].puzzle1);
             break;
 
         case O_PUZZLE_OPTION2:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].puzzle2);
+                Text_Create(0, -16, GF.levels[CurrentLevel].puzzle2);
             break;
 
         case O_PUZZLE_OPTION3:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].puzzle3);
+                Text_Create(0, -16, GF.levels[CurrentLevel].puzzle3);
             break;
 
         case O_PUZZLE_OPTION4:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].puzzle4);
+                Text_Create(0, -16, GF.levels[CurrentLevel].puzzle4);
             break;
 
         case O_KEY_OPTION1:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].key1);
+                Text_Create(0, -16, GF.levels[CurrentLevel].key1);
             break;
 
         case O_KEY_OPTION2:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].key2);
+                Text_Create(0, -16, GF.levels[CurrentLevel].key2);
             break;
 
         case O_KEY_OPTION3:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].key3);
+                Text_Create(0, -16, GF.levels[CurrentLevel].key3);
             break;
 
         case O_KEY_OPTION4:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].key4);
+                Text_Create(0, -16, GF.levels[CurrentLevel].key4);
             break;
 
         case O_PICKUP_OPTION1:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].pickup1);
+                Text_Create(0, -16, GF.levels[CurrentLevel].pickup1);
             break;
 
         case O_PICKUP_OPTION2:
             InvItemText[IT_NAME] =
-                T_Print(0, -16, GF.levels[CurrentLevel].pickup2);
+                Text_Create(0, -16, GF.levels[CurrentLevel].pickup2);
             break;
 
         case O_PASSPORT_OPTION:
             break;
 
         default:
-            InvItemText[IT_NAME] = T_Print(0, -16, inv_item->string);
+            InvItemText[IT_NAME] = Text_Create(0, -16, inv_item->string);
             break;
         }
 
         if (InvItemText[IT_NAME]) {
-            T_BottomAlign(InvItemText[IT_NAME], 1);
-            T_CentreH(InvItemText[IT_NAME], 1);
+            Text_AlignBottom(InvItemText[IT_NAME], 1);
+            Text_CentreH(InvItemText[IT_NAME], 1);
         }
     }
 
@@ -187,9 +188,9 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         if (!InvItemText[IT_QTY] && !(SaveGame.bonus_flag & GBF_NGPLUS)) {
             sprintf(temp_text, "%5d A", Lara.shotgun.ammo / SHOTGUN_AMMO_CLIP);
             Overlay_MakeAmmoString(temp_text);
-            InvItemText[IT_QTY] = T_Print(64, -56, temp_text);
-            T_BottomAlign(InvItemText[IT_QTY], 1);
-            T_CentreH(InvItemText[IT_QTY], 1);
+            InvItemText[IT_QTY] = Text_Create(64, -56, temp_text);
+            Text_AlignBottom(InvItemText[IT_QTY], 1);
+            Text_CentreH(InvItemText[IT_QTY], 1);
         }
         break;
 
@@ -197,9 +198,9 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         if (!InvItemText[IT_QTY] && !(SaveGame.bonus_flag & GBF_NGPLUS)) {
             sprintf(temp_text, "%5d B", Lara.magnums.ammo);
             Overlay_MakeAmmoString(temp_text);
-            InvItemText[IT_QTY] = T_Print(64, -56, temp_text);
-            T_BottomAlign(InvItemText[IT_QTY], 1);
-            T_CentreH(InvItemText[IT_QTY], 1);
+            InvItemText[IT_QTY] = Text_Create(64, -56, temp_text);
+            Text_AlignBottom(InvItemText[IT_QTY], 1);
+            Text_CentreH(InvItemText[IT_QTY], 1);
         }
         break;
 
@@ -207,9 +208,9 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         if (!InvItemText[IT_QTY] && !(SaveGame.bonus_flag & GBF_NGPLUS)) {
             sprintf(temp_text, "%5d C", Lara.uzis.ammo);
             Overlay_MakeAmmoString(temp_text);
-            InvItemText[IT_QTY] = T_Print(64, -56, temp_text);
-            T_BottomAlign(InvItemText[IT_QTY], 1);
-            T_CentreH(InvItemText[IT_QTY], 1);
+            InvItemText[IT_QTY] = Text_Create(64, -56, temp_text);
+            Text_AlignBottom(InvItemText[IT_QTY], 1);
+            Text_CentreH(InvItemText[IT_QTY], 1);
         }
         break;
 
@@ -217,9 +218,9 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         if (!InvItemText[IT_QTY]) {
             sprintf(temp_text, "%d", qty * NUM_SG_SHELLS);
             Overlay_MakeAmmoString(temp_text);
-            InvItemText[IT_QTY] = T_Print(64, -56, temp_text);
-            T_BottomAlign(InvItemText[IT_QTY], 1);
-            T_CentreH(InvItemText[IT_QTY], 1);
+            InvItemText[IT_QTY] = Text_Create(64, -56, temp_text);
+            Text_AlignBottom(InvItemText[IT_QTY], 1);
+            Text_CentreH(InvItemText[IT_QTY], 1);
         }
         break;
 
@@ -227,9 +228,9 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         if (!InvItemText[IT_QTY]) {
             sprintf(temp_text, "%d", Inv_RequestItem(O_MAG_AMMO_OPTION) * 2);
             Overlay_MakeAmmoString(temp_text);
-            InvItemText[IT_QTY] = T_Print(64, -56, temp_text);
-            T_BottomAlign(InvItemText[IT_QTY], 1);
-            T_CentreH(InvItemText[IT_QTY], 1);
+            InvItemText[IT_QTY] = Text_Create(64, -56, temp_text);
+            Text_AlignBottom(InvItemText[IT_QTY], 1);
+            Text_CentreH(InvItemText[IT_QTY], 1);
         }
         break;
 
@@ -237,9 +238,9 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         if (!InvItemText[IT_QTY]) {
             sprintf(temp_text, "%d", Inv_RequestItem(O_UZI_AMMO_OPTION) * 2);
             Overlay_MakeAmmoString(temp_text);
-            InvItemText[IT_QTY] = T_Print(64, -56, temp_text);
-            T_BottomAlign(InvItemText[IT_QTY], 1);
-            T_CentreH(InvItemText[IT_QTY], 1);
+            InvItemText[IT_QTY] = Text_Create(64, -56, temp_text);
+            Text_AlignBottom(InvItemText[IT_QTY], 1);
+            Text_CentreH(InvItemText[IT_QTY], 1);
         }
         break;
 
@@ -249,9 +250,9 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         if (!InvItemText[IT_QTY] && qty > 1) {
             sprintf(temp_text, "%d", qty);
             Overlay_MakeAmmoString(temp_text);
-            InvItemText[IT_QTY] = T_Print(64, -56, temp_text);
-            T_BottomAlign(InvItemText[IT_QTY], 1);
-            T_CentreH(InvItemText[IT_QTY], 1);
+            InvItemText[IT_QTY] = Text_Create(64, -56, temp_text);
+            Text_AlignBottom(InvItemText[IT_QTY], 1);
+            Text_CentreH(InvItemText[IT_QTY], 1);
         }
         break;
 
@@ -261,9 +262,9 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         if (!InvItemText[IT_QTY] && qty > 1) {
             sprintf(temp_text, "%d", qty);
             Overlay_MakeAmmoString(temp_text);
-            InvItemText[IT_QTY] = T_Print(64, -56, temp_text);
-            T_BottomAlign(InvItemText[IT_QTY], 1);
-            T_CentreH(InvItemText[IT_QTY], 1);
+            InvItemText[IT_QTY] = Text_Create(64, -56, temp_text);
+            Text_AlignBottom(InvItemText[IT_QTY], 1);
+            Text_CentreH(InvItemText[IT_QTY], 1);
         }
         break;
 
@@ -282,9 +283,9 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
         if (!InvItemText[IT_QTY] && qty > 1) {
             sprintf(temp_text, "%d", qty);
             Overlay_MakeAmmoString(temp_text);
-            InvItemText[IT_QTY] = T_Print(64, -56, temp_text);
-            T_BottomAlign(InvItemText[IT_QTY], 1);
-            T_CentreH(InvItemText[IT_QTY], 1);
+            InvItemText[IT_QTY] = Text_Create(64, -56, temp_text);
+            Text_AlignBottom(InvItemText[IT_QTY], 1);
+            Text_CentreH(InvItemText[IT_QTY], 1);
         }
         break;
     }
@@ -293,11 +294,11 @@ void RingNotActive(INVENTORY_ITEM *inv_item)
 void RingActive()
 {
     if (InvItemText[IT_NAME]) {
-        T_RemovePrint(InvItemText[IT_NAME]);
+        Text_Remove(InvItemText[IT_NAME]);
         InvItemText[IT_NAME] = NULL;
     }
     if (InvItemText[IT_QTY]) {
-        T_RemovePrint(InvItemText[IT_QTY]);
+        Text_Remove(InvItemText[IT_QTY]);
         InvItemText[IT_QTY] = NULL;
     }
 }
@@ -693,7 +694,7 @@ void RemoveInventoryText()
 {
     for (int i = 0; i < IT_NUMBER_OF; i++) {
         if (InvItemText[i]) {
-            T_RemovePrint(InvItemText[i]);
+            Text_Remove(InvItemText[i]);
             InvItemText[i] = NULL;
         }
     }

--- a/src/game/option.c
+++ b/src/game/option.c
@@ -645,7 +645,7 @@ void DoPassportOption(INVENTORY_ITEM *inv_item)
 
 void DoDetailOption(INVENTORY_ITEM *inv_item)
 {
-    static char buf[256];
+    char buf[256];
 
     if (!DetailTextHW[DETAIL_HW_TITLE_BORDER]) {
         int32_t y = DETAIL_HW_TOP_Y;
@@ -683,7 +683,7 @@ void DoDetailOption(INVENTORY_ITEM *inv_item)
         y += DETAIL_HW_ROW_HEIGHT;
 
         DetailTextHW[DETAIL_HW_RESOLUTION] = Text_Create(0, y, " ");
-        static char tmp[10];
+        char tmp[10];
         sprintf(tmp, "%dx%d", GetGameScreenWidth(), GetGameScreenHeight());
         sprintf(buf, GF.strings[GS_DETAIL_VIDEO_MODE_FMT], tmp);
         DetailTextHW[DETAIL_HW_RESOLUTION] = Text_Create(0, y, buf);
@@ -826,7 +826,7 @@ void DoDetailOption(INVENTORY_ITEM *inv_item)
 
 void DoSoundOption(INVENTORY_ITEM *inv_item)
 {
-    static char buf[20];
+    char buf[20];
 
     if (!SoundText[0]) {
         if (T1MConfig.music_volume > 10) {
@@ -938,8 +938,8 @@ void DoSoundOption(INVENTORY_ITEM *inv_item)
 
 void DoCompassOption(INVENTORY_ITEM *inv_item)
 {
-    static char buf[100];
-    static char time_buf[100];
+    char buf[100];
+    char time_buf[100];
 
     if (T1MConfig.enable_compass_stats) {
         if (!CompassText[0]) {

--- a/src/game/option.c
+++ b/src/game/option.c
@@ -398,7 +398,7 @@ void DoInventoryOptions(INVENTORY_ITEM *inv_item)
 
 void DoPassportOption(INVENTORY_ITEM *inv_item)
 {
-    T_RemovePrint(InvItemText[0]);
+    Text_Remove(InvItemText[0]);
     InvItemText[IT_NAME] = NULL;
 
     int16_t page = (inv_item->goal_frame - inv_item->open_frame) / 5;
@@ -437,14 +437,14 @@ void DoPassportOption(INVENTORY_ITEM *inv_item)
             } else {
                 if (!PassportText) {
                     PassportText =
-                        T_Print(0, -16, GF.strings[GS_PASSPORT_LOAD_GAME]);
-                    T_BottomAlign(PassportText, 1);
-                    T_CentreH(PassportText, 1);
+                        Text_Create(0, -16, GF.strings[GS_PASSPORT_LOAD_GAME]);
+                    Text_AlignBottom(PassportText, 1);
+                    Text_CentreH(PassportText, 1);
                 }
                 if (InputDB.select || InvMode == INV_LOAD_MODE) {
-                    T_RemovePrint(InvRingText);
+                    Text_Remove(InvRingText);
                     InvRingText = NULL;
-                    T_RemovePrint(InvItemText[IT_NAME]);
+                    Text_Remove(InvItemText[IT_NAME]);
                     InvItemText[IT_NAME] = NULL;
 
                     LoadSaveGameRequester.flags |= RIF_BLOCKABLE;
@@ -503,21 +503,21 @@ void DoPassportOption(INVENTORY_ITEM *inv_item)
                 if (InvMode == INV_TITLE_MODE
                     || CurrentLevel == GF.gym_level_num) {
                     PassportText =
-                        T_Print(0, -16, GF.strings[GS_PASSPORT_NEW_GAME]);
+                        Text_Create(0, -16, GF.strings[GS_PASSPORT_NEW_GAME]);
                 } else {
                     PassportText =
-                        T_Print(0, -16, GF.strings[GS_PASSPORT_SAVE_GAME]);
+                        Text_Create(0, -16, GF.strings[GS_PASSPORT_SAVE_GAME]);
                 }
-                T_BottomAlign(PassportText, 1);
-                T_CentreH(PassportText, 1);
+                Text_AlignBottom(PassportText, 1);
+                Text_CentreH(PassportText, 1);
             }
             if (InputDB.select || InvMode == INV_SAVE_MODE
                 || InvMode == INV_SAVE_CRYSTAL_MODE) {
                 if (InvMode == INV_TITLE_MODE
                     || CurrentLevel == GF.gym_level_num) {
-                    T_RemovePrint(InvRingText);
+                    Text_Remove(InvRingText);
                     InvRingText = NULL;
-                    T_RemovePrint(InvItemText[IT_NAME]);
+                    Text_Remove(InvItemText[IT_NAME]);
                     InvItemText[IT_NAME] = NULL;
 
                     if (GF.enable_game_modes) {
@@ -529,9 +529,9 @@ void DoPassportOption(INVENTORY_ITEM *inv_item)
                         InvExtraData[1] = SaveGame.bonus_flag;
                     }
                 } else {
-                    T_RemovePrint(InvRingText);
+                    Text_Remove(InvRingText);
                     InvRingText = NULL;
-                    T_RemovePrint(InvItemText[IT_NAME]);
+                    Text_Remove(InvItemText[IT_NAME]);
                     InvItemText[IT_NAME] = NULL;
 
                     LoadSaveGameRequester.flags &= ~RIF_BLOCKABLE;
@@ -548,13 +548,13 @@ void DoPassportOption(INVENTORY_ITEM *inv_item)
         if (!PassportText) {
             if (InvMode == INV_TITLE_MODE) {
                 PassportText =
-                    T_Print(0, -16, GF.strings[GS_PASSPORT_EXIT_GAME]);
+                    Text_Create(0, -16, GF.strings[GS_PASSPORT_EXIT_GAME]);
             } else {
                 PassportText =
-                    T_Print(0, -16, GF.strings[GS_PASSPORT_EXIT_TO_TITLE]);
+                    Text_Create(0, -16, GF.strings[GS_PASSPORT_EXIT_TO_TITLE]);
             }
-            T_BottomAlign(PassportText, 1);
-            T_CentreH(PassportText, 1);
+            Text_AlignBottom(PassportText, 1);
+            Text_CentreH(PassportText, 1);
         }
         break;
     }
@@ -578,7 +578,7 @@ void DoPassportOption(INVENTORY_ITEM *inv_item)
             inv_item->goal_frame = inv_item->open_frame + 5 * page;
             SoundEffect(SFX_MENU_PASSPORT, NULL, SPM_ALWAYS);
             if (PassportText) {
-                T_RemovePrint(PassportText);
+                Text_Remove(PassportText);
                 PassportText = NULL;
             }
         }
@@ -602,7 +602,7 @@ void DoPassportOption(INVENTORY_ITEM *inv_item)
             inv_item->goal_frame = inv_item->open_frame + 5 * page;
             SoundEffect(SFX_MENU_PASSPORT, NULL, SPM_ALWAYS);
             if (PassportText) {
-                T_RemovePrint(PassportText);
+                Text_Remove(PassportText);
                 PassportText = NULL;
             }
         }
@@ -621,7 +621,7 @@ void DoPassportOption(INVENTORY_ITEM *inv_item)
                 inv_item->anim_direction = -1;
             }
             if (PassportText) {
-                T_RemovePrint(PassportText);
+                Text_Remove(PassportText);
                 PassportText = NULL;
             }
         }
@@ -637,7 +637,7 @@ void DoPassportOption(INVENTORY_ITEM *inv_item)
             inv_item->anim_direction = -1;
         }
         if (PassportText) {
-            T_RemovePrint(PassportText);
+            Text_Remove(PassportText);
             PassportText = NULL;
         }
     }
@@ -649,10 +649,10 @@ void DoDetailOption(INVENTORY_ITEM *inv_item)
 
     if (!DetailTextHW[DETAIL_HW_TITLE_BORDER]) {
         int32_t y = DETAIL_HW_TOP_Y;
-        DetailTextHW[DETAIL_HW_TITLE_BORDER] = T_Print(0, y - 2, " ");
+        DetailTextHW[DETAIL_HW_TITLE_BORDER] = Text_Create(0, y - 2, " ");
 
         DetailTextHW[DETAIL_HW_TITLE] =
-            T_Print(0, y, GF.strings[GS_DETAIL_SELECT_DETAIL]);
+            Text_Create(0, y, GF.strings[GS_DETAIL_SELECT_DETAIL]);
         y += DETAIL_HW_ROW_HEIGHT;
 
         sprintf(
@@ -660,33 +660,33 @@ void DoDetailOption(INVENTORY_ITEM *inv_item)
             GF.strings
                 [T1MConfig.render_flags.perspective ? GS_MISC_ON
                                                     : GS_MISC_OFF]);
-        DetailTextHW[DETAIL_HW_PERSPECTIVE] = T_Print(0, y, buf);
+        DetailTextHW[DETAIL_HW_PERSPECTIVE] = Text_Create(0, y, buf);
         y += DETAIL_HW_ROW_HEIGHT;
 
         sprintf(
             buf, GF.strings[GS_DETAIL_BILINEAR_FMT],
             GF.strings
                 [T1MConfig.render_flags.bilinear ? GS_MISC_ON : GS_MISC_OFF]);
-        DetailTextHW[DETAIL_HW_BILINEAR] = T_Print(0, y, buf);
+        DetailTextHW[DETAIL_HW_BILINEAR] = Text_Create(0, y, buf);
         y += DETAIL_HW_ROW_HEIGHT;
 
         sprintf(
             buf, GF.strings[GS_DETAIL_UI_TEXT_SCALE_FMT],
             T1MConfig.ui.text_scale);
-        DetailTextHW[DETAIL_HW_UI_TEXT_SCALE] = T_Print(0, y, buf);
+        DetailTextHW[DETAIL_HW_UI_TEXT_SCALE] = Text_Create(0, y, buf);
         y += DETAIL_HW_ROW_HEIGHT;
 
         sprintf(
             buf, GF.strings[GS_DETAIL_UI_BAR_SCALE_FMT],
             T1MConfig.ui.bar_scale);
-        DetailTextHW[DETAIL_HW_UI_BAR_SCALE] = T_Print(0, y, buf);
+        DetailTextHW[DETAIL_HW_UI_BAR_SCALE] = Text_Create(0, y, buf);
         y += DETAIL_HW_ROW_HEIGHT;
 
-        DetailTextHW[DETAIL_HW_RESOLUTION] = T_Print(0, y, " ");
+        DetailTextHW[DETAIL_HW_RESOLUTION] = Text_Create(0, y, " ");
         static char tmp[10];
         sprintf(tmp, "%dx%d", GetGameScreenWidth(), GetGameScreenHeight());
         sprintf(buf, GF.strings[GS_DETAIL_VIDEO_MODE_FMT], tmp);
-        DetailTextHW[DETAIL_HW_RESOLUTION] = T_Print(0, y, buf);
+        DetailTextHW[DETAIL_HW_RESOLUTION] = Text_Create(0, y, buf);
         y += DETAIL_HW_ROW_HEIGHT;
 
         if (OptionSelected < DETAIL_HW_OPTION_MIN) {
@@ -696,40 +696,40 @@ void DoDetailOption(INVENTORY_ITEM *inv_item)
             OptionSelected = DETAIL_HW_OPTION_MAX;
         }
 
-        T_AddBackground(
+        Text_AddBackground(
             DetailTextHW[DETAIL_HW_TITLE_BORDER], DETAIL_HW_ROW_WIDHT,
             y - DETAIL_HW_TOP_Y, 0, 0);
-        T_AddOutline(DetailTextHW[DETAIL_HW_TITLE_BORDER], 1);
+        Text_AddOutline(DetailTextHW[DETAIL_HW_TITLE_BORDER], 1);
 
-        T_AddBackground(
+        Text_AddBackground(
             DetailTextHW[DETAIL_HW_TITLE], DETAIL_HW_ROW_WIDHT - 4, 0, 0, 0);
-        T_AddOutline(DetailTextHW[DETAIL_HW_TITLE], 1);
+        Text_AddOutline(DetailTextHW[DETAIL_HW_TITLE], 1);
 
-        T_AddBackground(
+        Text_AddBackground(
             DetailTextHW[OptionSelected], DETAIL_HW_ROW_WIDHT - 12, 0, 0, 0);
-        T_AddOutline(DetailTextHW[OptionSelected], 1);
+        Text_AddOutline(DetailTextHW[OptionSelected], 1);
 
         for (int i = 0; i < DETAIL_HW_NUMBER_OF; i++) {
-            T_CentreH(DetailTextHW[i], 1);
-            T_CentreV(DetailTextHW[i], 1);
+            Text_CentreH(DetailTextHW[i], 1);
+            Text_CentreV(DetailTextHW[i], 1);
         }
     }
 
     if (InputDB.forward && OptionSelected > DETAIL_HW_OPTION_MIN) {
-        T_RemoveOutline(DetailTextHW[OptionSelected]);
-        T_RemoveBackground(DetailTextHW[OptionSelected]);
+        Text_RemoveOutline(DetailTextHW[OptionSelected]);
+        Text_RemoveBackground(DetailTextHW[OptionSelected]);
         OptionSelected--;
-        T_AddOutline(DetailTextHW[OptionSelected], 1);
-        T_AddBackground(
+        Text_AddOutline(DetailTextHW[OptionSelected], 1);
+        Text_AddBackground(
             DetailTextHW[OptionSelected], DETAIL_HW_ROW_WIDHT - 12, 0, 0, 0);
     }
 
     if (InputDB.back && OptionSelected < DETAIL_HW_OPTION_MAX) {
-        T_RemoveOutline(DetailTextHW[OptionSelected]);
-        T_RemoveBackground(DetailTextHW[OptionSelected]);
+        Text_RemoveOutline(DetailTextHW[OptionSelected]);
+        Text_RemoveBackground(DetailTextHW[OptionSelected]);
         OptionSelected++;
-        T_AddOutline(DetailTextHW[OptionSelected], 1);
-        T_AddBackground(
+        Text_AddOutline(DetailTextHW[OptionSelected], 1);
+        Text_AddBackground(
             DetailTextHW[OptionSelected], DETAIL_HW_ROW_WIDHT - 12, 0, 0, 0);
     }
 
@@ -817,7 +817,7 @@ void DoDetailOption(INVENTORY_ITEM *inv_item)
 
     if (reset) {
         for (int i = 0; i < DETAIL_HW_NUMBER_OF; i++) {
-            T_RemovePrint(DetailTextHW[i]);
+            Text_Remove(DetailTextHW[i]);
             DetailTextHW[i] = NULL;
         }
         S_WriteUserSettings();
@@ -833,43 +833,43 @@ void DoSoundOption(INVENTORY_ITEM *inv_item)
             T1MConfig.music_volume = 10;
         }
         sprintf(buf, "| %2d", T1MConfig.music_volume);
-        SoundText[SOUND_MUSIC_VOLUME] = T_Print(0, 0, buf);
+        SoundText[SOUND_MUSIC_VOLUME] = Text_Create(0, 0, buf);
 
         if (T1MConfig.sound_volume > 10) {
             T1MConfig.sound_volume = 10;
         }
         sprintf(buf, "} %2d", T1MConfig.sound_volume);
-        SoundText[SOUND_SOUND_VOLUME] = T_Print(0, 25, buf);
+        SoundText[SOUND_SOUND_VOLUME] = Text_Create(0, 25, buf);
 
         SoundText[SOUND_TITLE] =
-            T_Print(0, -30, GF.strings[GS_SOUND_SET_VOLUMES]);
-        SoundText[SOUND_TITLE_BORDER] = T_Print(0, -32, " ");
+            Text_Create(0, -30, GF.strings[GS_SOUND_SET_VOLUMES]);
+        SoundText[SOUND_TITLE_BORDER] = Text_Create(0, -32, " ");
 
-        T_AddBackground(SoundText[OptionSelected], 128, 0, 0, 0);
-        T_AddOutline(SoundText[OptionSelected], 1);
-        T_AddBackground(SoundText[SOUND_TITLE], 136, 0, 0, 0);
-        T_AddOutline(SoundText[SOUND_TITLE], 1);
-        T_AddBackground(SoundText[SOUND_TITLE_BORDER], 140, 85, 0, 0);
-        T_AddOutline(SoundText[SOUND_TITLE_BORDER], 1);
+        Text_AddBackground(SoundText[OptionSelected], 128, 0, 0, 0);
+        Text_AddOutline(SoundText[OptionSelected], 1);
+        Text_AddBackground(SoundText[SOUND_TITLE], 136, 0, 0, 0);
+        Text_AddOutline(SoundText[SOUND_TITLE], 1);
+        Text_AddBackground(SoundText[SOUND_TITLE_BORDER], 140, 85, 0, 0);
+        Text_AddOutline(SoundText[SOUND_TITLE_BORDER], 1);
 
         for (int i = 0; i < SOUND_NUMBER_OF; i++) {
-            T_CentreH(SoundText[i], 1);
-            T_CentreV(SoundText[i], 1);
+            Text_CentreH(SoundText[i], 1);
+            Text_CentreV(SoundText[i], 1);
         }
     }
 
     if (InputDB.forward && OptionSelected > SOUND_OPTION_MIN) {
-        T_RemoveOutline(SoundText[OptionSelected]);
-        T_RemoveBackground(SoundText[OptionSelected]);
-        T_AddBackground(SoundText[--OptionSelected], 128, 0, 0, 0);
-        T_AddOutline(SoundText[OptionSelected], 1);
+        Text_RemoveOutline(SoundText[OptionSelected]);
+        Text_RemoveBackground(SoundText[OptionSelected]);
+        Text_AddBackground(SoundText[--OptionSelected], 128, 0, 0, 0);
+        Text_AddOutline(SoundText[OptionSelected], 1);
     }
 
     if (InputDB.back && OptionSelected < SOUND_OPTION_MAX) {
-        T_RemoveOutline(SoundText[OptionSelected]);
-        T_RemoveBackground(SoundText[OptionSelected]);
-        T_AddBackground(SoundText[++OptionSelected], 128, 0, 0, 0);
-        T_AddOutline(SoundText[OptionSelected], 1);
+        Text_RemoveOutline(SoundText[OptionSelected]);
+        Text_RemoveBackground(SoundText[OptionSelected]);
+        Text_AddBackground(SoundText[++OptionSelected], 128, 0, 0, 0);
+        Text_AddOutline(SoundText[OptionSelected], 1);
     }
 
     switch (OptionSelected) {
@@ -879,14 +879,14 @@ void DoSoundOption(INVENTORY_ITEM *inv_item)
             IDelay = true;
             IDCount = 10;
             sprintf(buf, "| %2d", T1MConfig.music_volume);
-            T_ChangeText(SoundText[SOUND_MUSIC_VOLUME], buf);
+            Text_ChangeText(SoundText[SOUND_MUSIC_VOLUME], buf);
             S_WriteUserSettings();
         } else if (Input.right && T1MConfig.music_volume < 10) {
             T1MConfig.music_volume++;
             IDelay = true;
             IDCount = 10;
             sprintf(buf, "| %2d", T1MConfig.music_volume);
-            T_ChangeText(SoundText[SOUND_MUSIC_VOLUME], buf);
+            Text_ChangeText(SoundText[SOUND_MUSIC_VOLUME], buf);
             S_WriteUserSettings();
         }
 
@@ -906,14 +906,14 @@ void DoSoundOption(INVENTORY_ITEM *inv_item)
             IDelay = true;
             IDCount = 10;
             sprintf(buf, "} %2d", T1MConfig.sound_volume);
-            T_ChangeText(SoundText[SOUND_SOUND_VOLUME], buf);
+            Text_ChangeText(SoundText[SOUND_SOUND_VOLUME], buf);
             S_WriteUserSettings();
         } else if (Input.right && T1MConfig.sound_volume < 10) {
             T1MConfig.sound_volume++;
             IDelay = true;
             IDCount = 10;
             sprintf(buf, "} %2d", T1MConfig.sound_volume);
-            T_ChangeText(SoundText[SOUND_SOUND_VOLUME], buf);
+            Text_ChangeText(SoundText[SOUND_SOUND_VOLUME], buf);
             S_WriteUserSettings();
         }
 
@@ -930,7 +930,7 @@ void DoSoundOption(INVENTORY_ITEM *inv_item)
 
     if (InputDB.deselect || InputDB.select) {
         for (int i = 0; i < SOUND_NUMBER_OF; i++) {
-            T_RemovePrint(SoundText[i]);
+            Text_Remove(SoundText[i]);
             SoundText[i] = NULL;
         }
     }
@@ -945,13 +945,13 @@ void DoCompassOption(INVENTORY_ITEM *inv_item)
         if (!CompassText[0]) {
             int32_t y = COMPASS_TOP_Y;
 
-            CompassText[COMPASS_TITLE_BORDER] = T_Print(0, y - 2, " ");
+            CompassText[COMPASS_TITLE_BORDER] = Text_Create(0, y - 2, " ");
 
             sprintf(buf, "%s", GF.levels[CurrentLevel].level_title);
-            CompassText[COMPASS_TITLE] = T_Print(0, y, buf);
+            CompassText[COMPASS_TITLE] = Text_Create(0, y, buf);
             y += COMPASS_ROW_HEIGHT;
 
-            CompassText[COMPASS_TIME] = T_Print(0, y, " ");
+            CompassText[COMPASS_TIME] = Text_Create(0, y, " ");
             y += COMPASS_ROW_HEIGHT;
 
             int32_t secrets_taken = 0;
@@ -967,28 +967,28 @@ void DoCompassOption(INVENTORY_ITEM *inv_item)
             sprintf(
                 buf, GF.strings[GS_STATS_SECRETS_FMT], secrets_taken,
                 GF.levels[CurrentLevel].secrets);
-            CompassText[COMPASS_SECRETS] = T_Print(0, y, buf);
+            CompassText[COMPASS_SECRETS] = Text_Create(0, y, buf);
             y += COMPASS_ROW_HEIGHT;
 
             sprintf(buf, GF.strings[GS_STATS_PICKUPS_FMT], SaveGame.pickups);
-            CompassText[COMPASS_PICKUPS] = T_Print(0, y, buf);
+            CompassText[COMPASS_PICKUPS] = Text_Create(0, y, buf);
             y += COMPASS_ROW_HEIGHT;
 
             sprintf(buf, GF.strings[GS_STATS_KILLS_FMT], SaveGame.kills);
-            CompassText[COMPASS_KILLS] = T_Print(0, y, buf);
+            CompassText[COMPASS_KILLS] = Text_Create(0, y, buf);
             y += COMPASS_ROW_HEIGHT;
 
-            T_AddBackground(
+            Text_AddBackground(
                 CompassText[COMPASS_TITLE_BORDER], COMPASS_ROW_WIDTH,
                 y - COMPASS_TOP_Y, 0, 0);
-            T_AddOutline(CompassText[COMPASS_TITLE_BORDER], 1);
-            T_AddBackground(
+            Text_AddOutline(CompassText[COMPASS_TITLE_BORDER], 1);
+            Text_AddBackground(
                 CompassText[COMPASS_TITLE], COMPASS_ROW_WIDTH - 4, 0, 0, 0);
-            T_AddOutline(CompassText[COMPASS_TITLE], 1);
+            Text_AddOutline(CompassText[COMPASS_TITLE], 1);
 
             for (int i = 0; i < COMPASS_NUMBER_OF; i++) {
-                T_CentreH(CompassText[i], 1);
-                T_CentreV(CompassText[i], 1);
+                Text_CentreH(CompassText[i], 1);
+                Text_CentreV(CompassText[i], 1);
             }
         }
 
@@ -1004,12 +1004,12 @@ void DoCompassOption(INVENTORY_ITEM *inv_item)
             sprintf(time_buf, "%d:%d%d", minutes, seconds / 10, seconds % 10);
         }
         sprintf(buf, GF.strings[GS_STATS_TIME_TAKEN_FMT], time_buf);
-        T_ChangeText(CompassText[COMPASS_TIME], buf);
+        Text_ChangeText(CompassText[COMPASS_TIME], buf);
     }
 
     if (InputDB.deselect || InputDB.select) {
         for (int i = 0; i < COMPASS_NUMBER_OF; i++) {
-            T_RemovePrint(CompassText[i]);
+            Text_Remove(CompassText[i]);
             CompassText[i] = NULL;
         }
         inv_item->goal_frame = inv_item->frames_total - 1;
@@ -1025,7 +1025,7 @@ void FlashConflicts()
 
     for (const TEXT_COLUMN_PLACEMENT *item = cols; item->col_num != -1;
          item++) {
-        T_FlashText(CtrlTextB[item->option], 0, 0);
+        Text_Flash(CtrlTextB[item->option], 0, 0);
     }
 
     for (const TEXT_COLUMN_PLACEMENT *item1 = cols; item1->col_num != -1;
@@ -1041,8 +1041,8 @@ void FlashConflicts()
             }
             int16_t key2 = Layout[T1MConfig.input.layout][item2->option];
             if (item1 != item2 && key1 == key2) {
-                T_FlashText(CtrlTextB[item1->option], 1, 20);
-                T_FlashText(CtrlTextB[item2->option], 1, 20);
+                Text_Flash(CtrlTextB[item1->option], 1, 20);
+                Text_Flash(CtrlTextB[item2->option], 1, 20);
             }
         }
     }
@@ -1067,7 +1067,7 @@ void DoControlOption(INVENTORY_ITEM *inv_item)
     int16_t key;
 
     if (!CtrlText[0]) {
-        CtrlText[0] = T_Print(
+        CtrlText[0] = Text_Create(
             0,
             CONTROLS_TOP_Y - CONTROLS_BORDER
                 + (CONTROLS_HEADER_HEIGHT + CONTROLS_BORDER
@@ -1076,13 +1076,13 @@ void DoControlOption(INVENTORY_ITEM *inv_item)
             GF.strings
                 [T1MConfig.input.layout ? GS_CONTROL_USER_KEYS
                                         : GS_CONTROL_DEFAULT_KEYS]);
-        T_CentreH(CtrlText[0], 1);
-        T_CentreV(CtrlText[0], 1);
+        Text_CentreH(CtrlText[0], 1);
+        Text_CentreV(CtrlText[0], 1);
         S_ShowControls();
 
         KeyChange = -1;
-        T_AddBackground(CtrlText[0], 0, 0, 0, 0);
-        T_AddOutline(CtrlText[0], 1);
+        Text_AddBackground(CtrlText[0], 0, 0, 0, 0);
+        Text_AddOutline(CtrlText[0], 1);
     }
 
     const TEXT_COLUMN_PLACEMENT *cols = T1MConfig.enable_cheats
@@ -1110,8 +1110,8 @@ void DoControlOption(INVENTORY_ITEM *inv_item)
                 FlashConflicts();
                 S_WriteUserSettings();
             } else {
-                T_RemoveBackground(CtrlTextA[KeyChange]);
-                T_RemoveOutline(CtrlTextA[KeyChange]);
+                Text_RemoveBackground(CtrlTextA[KeyChange]);
+                Text_RemoveOutline(CtrlTextA[KeyChange]);
 
                 int col_idx[2] = { 0, 0 };
                 const TEXT_COLUMN_PLACEMENT *sel_col;
@@ -1140,8 +1140,8 @@ void DoControlOption(INVENTORY_ITEM *inv_item)
                     }
                 }
 
-                T_AddBackground(CtrlTextA[KeyChange], 0, 0, 0, 0);
-                T_AddOutline(CtrlTextA[KeyChange], 1);
+                Text_AddBackground(CtrlTextA[KeyChange], 0, 0, 0, 0);
+                Text_AddOutline(CtrlTextA[KeyChange], 1);
             }
         } else if (InputDB.deselect || (InputDB.select && KeyChange == -1)) {
             S_RemoveCtrl();
@@ -1152,14 +1152,14 @@ void DoControlOption(INVENTORY_ITEM *inv_item)
         if (T1MConfig.input.layout) {
             if (InputDB.select) {
                 KeyMode = 1;
-                T_RemoveBackground(CtrlTextA[KeyChange]);
-                T_AddBackground(CtrlTextB[KeyChange], 0, 0, 0, 0);
-                T_RemoveOutline(CtrlTextA[KeyChange]);
-                T_AddOutline(CtrlTextB[KeyChange], 1);
+                Text_RemoveBackground(CtrlTextA[KeyChange]);
+                Text_AddBackground(CtrlTextB[KeyChange], 0, 0, 0, 0);
+                Text_RemoveOutline(CtrlTextA[KeyChange]);
+                Text_AddOutline(CtrlTextB[KeyChange], 1);
             } else if (InputDB.forward) {
-                T_RemoveBackground(
+                Text_RemoveBackground(
                     KeyChange == -1 ? CtrlText[0] : CtrlTextA[KeyChange]);
-                T_RemoveOutline(
+                Text_RemoveOutline(
                     KeyChange == -1 ? CtrlText[0] : CtrlTextA[KeyChange]);
 
                 if (KeyChange == -1) {
@@ -1185,15 +1185,15 @@ void DoControlOption(INVENTORY_ITEM *inv_item)
                     }
                 }
 
-                T_AddBackground(
+                Text_AddBackground(
                     KeyChange == -1 ? CtrlText[0] : CtrlTextA[KeyChange], 0, 0,
                     0, 0);
-                T_AddOutline(
+                Text_AddOutline(
                     KeyChange == -1 ? CtrlText[0] : CtrlTextA[KeyChange], 1);
             } else if (InputDB.back) {
-                T_RemoveBackground(
+                Text_RemoveBackground(
                     KeyChange == -1 ? CtrlText[0] : CtrlTextA[KeyChange]);
-                T_RemoveOutline(
+                Text_RemoveOutline(
                     KeyChange == -1 ? CtrlText[0] : CtrlTextA[KeyChange]);
 
                 if (KeyChange == -1) {
@@ -1219,10 +1219,10 @@ void DoControlOption(INVENTORY_ITEM *inv_item)
                     }
                 }
 
-                T_AddBackground(
+                Text_AddBackground(
                     KeyChange == -1 ? CtrlText[0] : CtrlTextA[KeyChange], 0, 0,
                     0, 0);
-                T_AddOutline(
+                Text_AddOutline(
                     KeyChange == -1 ? CtrlText[0] : CtrlTextA[KeyChange], 1);
             }
         }
@@ -1242,11 +1242,11 @@ void DoControlOption(INVENTORY_ITEM *inv_item)
             && key != DIK_LEFT && key != DIK_RIGHT && key != DIK_UP
             && key != DIK_DOWN) {
             Layout[T1MConfig.input.layout][KeyChange] = key;
-            T_ChangeText(CtrlTextB[KeyChange], scancode_name);
-            T_RemoveBackground(CtrlTextB[KeyChange]);
-            T_RemoveOutline(CtrlTextB[KeyChange]);
-            T_AddBackground(CtrlTextA[KeyChange], 0, 0, 0, 0);
-            T_AddOutline(CtrlTextA[KeyChange], 1);
+            Text_ChangeText(CtrlTextB[KeyChange], scancode_name);
+            Text_RemoveBackground(CtrlTextB[KeyChange]);
+            Text_RemoveOutline(CtrlTextB[KeyChange]);
+            Text_AddBackground(CtrlTextA[KeyChange], 0, 0, 0, 0);
+            Text_AddOutline(CtrlTextA[KeyChange], 1);
             KeyMode = 3;
             FlashConflicts();
             S_WriteUserSettings();
@@ -1275,9 +1275,9 @@ void S_ShowControls()
     const int16_t centre = GetRenderWidthDownscaled() / 2;
     int16_t max_y = 0;
 
-    CtrlText[1] = T_Print(0, CONTROLS_TOP_Y - CONTROLS_BORDER, " ");
-    T_CentreH(CtrlText[1], 1);
-    T_CentreV(CtrlText[1], 1);
+    CtrlText[1] = Text_Create(0, CONTROLS_TOP_Y - CONTROLS_BORDER, " ");
+    Text_CentreH(CtrlText[1], 1);
+    Text_CentreV(CtrlText[1], 1);
 
     const TEXT_COLUMN_PLACEMENT *cols = T1MConfig.enable_cheats
         ? CtrlTextPlacementCheats
@@ -1296,8 +1296,8 @@ void S_ShowControls()
 
             const char *scancode_name = GetScanCodeName(layout[col->option]);
             if (col->option != -1 && scancode_name) {
-                CtrlTextB[col->option] = T_Print(x, y, scancode_name);
-                T_CentreV(CtrlTextB[col->option], 1);
+                CtrlTextB[col->option] = Text_Create(x, y, scancode_name);
+                Text_CentreV(CtrlTextB[col->option], 1);
             }
 
             ys[col->col_num] += CONTROLS_ROW_HEIGHT;
@@ -1318,9 +1318,9 @@ void S_ShowControls()
             int16_t y = ys[col->col_num];
 
             if (col->option != -1) {
-                CtrlTextA[col->option] = T_Print(
+                CtrlTextA[col->option] = Text_Create(
                     x, y, GF.strings[col->option + GS_KEYMAP_RUN - KEY_UP]);
-                T_CentreV(CtrlTextA[col->option], 1);
+                Text_CentreV(CtrlTextA[col->option], 1);
             }
 
             ys[col->col_num] += CONTROLS_ROW_HEIGHT;
@@ -1330,15 +1330,15 @@ void S_ShowControls()
 
     int16_t width = 420;
     int16_t height = max_y + CONTROLS_BORDER * 2 - CONTROLS_TOP_Y;
-    T_AddBackground(CtrlText[1], width, height, 0, 0);
-    T_AddOutline(CtrlText[1], 1);
+    Text_AddBackground(CtrlText[1], width, height, 0, 0);
+    Text_AddOutline(CtrlText[1], 1);
 
     FlashConflicts();
 }
 
 void S_ChangeCtrlText()
 {
-    T_ChangeText(
+    Text_ChangeText(
         CtrlText[0],
         GF.strings
             [T1MConfig.input.layout ? GS_CONTROL_USER_KEYS
@@ -1353,7 +1353,7 @@ void S_ChangeCtrlText()
          col->col_num >= 0 && col->col_num <= 1; col++) {
         const char *scancode_name = GetScanCodeName(layout[col->option]);
         if (col->option != -1 && scancode_name) {
-            T_ChangeText(CtrlTextB[col->option], scancode_name);
+            Text_ChangeText(CtrlTextB[col->option], scancode_name);
         }
     }
 }
@@ -1361,8 +1361,8 @@ void S_ChangeCtrlText()
 void S_RemoveCtrlText()
 {
     for (int i = 0; i < KEY_NUMBER_OF; i++) {
-        T_RemovePrint(CtrlTextA[i]);
-        T_RemovePrint(CtrlTextB[i]);
+        Text_Remove(CtrlTextA[i]);
+        Text_Remove(CtrlTextB[i]);
         CtrlTextB[i] = NULL;
         CtrlTextA[i] = NULL;
     }
@@ -1370,8 +1370,8 @@ void S_RemoveCtrlText()
 
 void S_RemoveCtrl()
 {
-    T_RemovePrint(CtrlText[0]);
-    T_RemovePrint(CtrlText[1]);
+    Text_Remove(CtrlText[0]);
+    Text_Remove(CtrlText[1]);
     CtrlText[0] = NULL;
     CtrlText[1] = NULL;
     S_RemoveCtrlText();

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -378,15 +378,16 @@ void Overlay_DrawPickups()
 
 void Overlay_DrawFPSInfo()
 {
-    static char fps_buf[20];
     static int32_t elapsed = 0;
 
     if (T1MConfig.render_flags.fps_counter) {
         if (ClockGetMS() - elapsed >= 1000) {
             if (FPSText) {
+                char fps_buf[20];
                 sprintf(fps_buf, "%d FPS", FPSCounter);
                 Text_ChangeText(FPSText, fps_buf);
             } else {
+                char fps_buf[20];
                 sprintf(fps_buf, "? FPS");
                 FPSText = Text_Create(10, 30, fps_buf);
             }

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -80,6 +80,8 @@ static RGB888 ColorBarMap[][COLOR_STEPS] = {
 static void Overlay_GetBarLocation(
     int8_t bar_location, int32_t width, int32_t height, int32_t *x, int32_t *y);
 static void Overlay_DrawBar(int32_t value, int32_t value_max, int32_t bar_type);
+static void Overlay_OnAmmoTextRemoval(const TEXTSTRING *textstring);
+static void Overlay_OnFPSTextRemoval(const TEXTSTRING *textstring);
 
 static void Overlay_GetBarLocation(
     int8_t bar_location, int32_t width, int32_t height, int32_t *x, int32_t *y)
@@ -192,6 +194,16 @@ static void Overlay_DrawBar(int32_t value, int32_t value_max, int32_t bar_type)
             }
         }
     }
+}
+
+static void Overlay_OnAmmoTextRemoval(const TEXTSTRING *textstring)
+{
+    AmmoText = NULL;
+}
+
+static void Overlay_OnFPSTextRemoval(const TEXTSTRING *textstring)
+{
+    FPSText = NULL;
 }
 
 void Overlay_Init()
@@ -336,6 +348,7 @@ void Overlay_DrawAmmoInfo()
         AmmoText = Text_Create(
             -screen_margin_h - text_offset_x, text_height + screen_margin_v,
             ammostring);
+        AmmoText->on_remove = Overlay_OnAmmoTextRemoval;
         Text_SetScale(AmmoText, PHD_ONE * scale, PHD_ONE * scale);
         Text_AlignRight(AmmoText, 1);
     }
@@ -390,6 +403,7 @@ void Overlay_DrawFPSInfo()
                 char fps_buf[20];
                 sprintf(fps_buf, "? FPS");
                 FPSText = Text_Create(10, 30, fps_buf);
+                FPSText->on_remove = Overlay_OnFPSTextRemoval;
             }
             FPSCounter = 0;
             elapsed = ClockGetMS();

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -340,7 +340,7 @@ void Overlay_DrawAmmoInfo()
         Text_AlignRight(AmmoText, 1);
     }
 
-    AmmoText->ypos = BarOffsetY[T1M_BL_TOP_RIGHT]
+    AmmoText->pos.y = BarOffsetY[T1M_BL_TOP_RIGHT]
         ? text_height + screen_margin_v + BarOffsetY[T1M_BL_TOP_RIGHT]
         : text_height + screen_margin_v;
 }

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -17,8 +17,12 @@
 #define MAX_PICKUP_COLUMNS 4
 #define MAX_PICKUPS 16
 
-static int16_t BarOffsetY[6] = { 0 };
-static DISPLAYPU Pickups[MAX_PICKUPS] = { 0 };
+static struct {
+    TEXTSTRING *ammo_text;
+    TEXTSTRING *fps_text;
+    int16_t bar_offset_y[6];
+    DISPLAYPU pickups[MAX_PICKUPS];
+} S = { 0 };
 
 static RGB888 ColorBarMap[][COLOR_STEPS] = {
     // gold
@@ -103,13 +107,13 @@ static void Overlay_GetBarLocation(
 
     if (bar_location == T1M_BL_TOP_LEFT || bar_location == T1M_BL_TOP_CENTER
         || bar_location == T1M_BL_TOP_RIGHT) {
-        *y = screen_margin_v + BarOffsetY[bar_location];
+        *y = screen_margin_v + S.bar_offset_y[bar_location];
     } else {
         *y = GetRenderHeightDownscaled() - height * T1MConfig.ui.bar_scale
-            - screen_margin_v - BarOffsetY[bar_location];
+            - screen_margin_v - S.bar_offset_y[bar_location];
     }
 
-    BarOffsetY[bar_location] += height + bar_spacing;
+    S.bar_offset_y[bar_location] += height + bar_spacing;
 }
 
 static void Overlay_DrawBar(int32_t value, int32_t value_max, int32_t bar_type)
@@ -198,18 +202,18 @@ static void Overlay_DrawBar(int32_t value, int32_t value_max, int32_t bar_type)
 
 static void Overlay_OnAmmoTextRemoval(const TEXTSTRING *textstring)
 {
-    AmmoText = NULL;
+    S.ammo_text = NULL;
 }
 
 static void Overlay_OnFPSTextRemoval(const TEXTSTRING *textstring)
 {
-    FPSText = NULL;
+    S.fps_text = NULL;
 }
 
 void Overlay_Init()
 {
     for (int i = 0; i < MAX_PICKUPS; i++) {
-        Pickups[i].duration = 0;
+        S.pickups[i].duration = 0;
     }
 }
 
@@ -218,7 +222,7 @@ void Overlay_DrawHealthBar()
     static int32_t old_hit_points = 0;
 
     for (int i = 0; i < 6; i++) {
-        BarOffsetY[i] = 0;
+        S.bar_offset_y[i] = 0;
     }
 
     int hit_points = LaraItem->hit_points;
@@ -317,9 +321,9 @@ void Overlay_DrawAmmoInfo()
 
     if (Lara.gun_status != LGS_READY || OverlayFlag <= 0
         || (SaveGame.bonus_flag & GBF_NGPLUS)) {
-        if (AmmoText) {
-            Text_Remove(AmmoText);
-            AmmoText = NULL;
+        if (S.ammo_text) {
+            Text_Remove(S.ammo_text);
+            S.ammo_text = NULL;
         }
         return;
     }
@@ -342,19 +346,19 @@ void Overlay_DrawAmmoInfo()
 
     Overlay_MakeAmmoString(ammostring);
 
-    if (AmmoText) {
-        Text_ChangeText(AmmoText, ammostring);
+    if (S.ammo_text) {
+        Text_ChangeText(S.ammo_text, ammostring);
     } else {
-        AmmoText = Text_Create(
+        S.ammo_text = Text_Create(
             -screen_margin_h - text_offset_x, text_height + screen_margin_v,
             ammostring);
-        AmmoText->on_remove = Overlay_OnAmmoTextRemoval;
-        Text_SetScale(AmmoText, PHD_ONE * scale, PHD_ONE * scale);
-        Text_AlignRight(AmmoText, 1);
+        S.ammo_text->on_remove = Overlay_OnAmmoTextRemoval;
+        Text_SetScale(S.ammo_text, PHD_ONE * scale, PHD_ONE * scale);
+        Text_AlignRight(S.ammo_text, 1);
     }
 
-    AmmoText->pos.y = BarOffsetY[T1M_BL_TOP_RIGHT]
-        ? text_height + screen_margin_v + BarOffsetY[T1M_BL_TOP_RIGHT]
+    S.ammo_text->pos.y = S.bar_offset_y[T1M_BL_TOP_RIGHT]
+        ? text_height + screen_margin_v + S.bar_offset_y[T1M_BL_TOP_RIGHT]
         : text_height + screen_margin_v;
 }
 
@@ -370,7 +374,7 @@ void Overlay_DrawPickups()
         int32_t y = PhdWinHeight - sprite_height;
         int32_t x = PhdWinWidth - sprite_height;
         for (int i = 0; i < MAX_PICKUPS; i++) {
-            DISPLAYPU *pu = &Pickups[i];
+            DISPLAYPU *pu = &S.pickups[i];
             pu->duration -= time;
             if (pu->duration <= 0) {
                 pu->duration = 0;
@@ -395,22 +399,22 @@ void Overlay_DrawFPSInfo()
 
     if (T1MConfig.render_flags.fps_counter) {
         if (ClockGetMS() - elapsed >= 1000) {
-            if (FPSText) {
+            if (S.fps_text) {
                 char fps_buf[20];
                 sprintf(fps_buf, "%d FPS", FPSCounter);
-                Text_ChangeText(FPSText, fps_buf);
+                Text_ChangeText(S.fps_text, fps_buf);
             } else {
                 char fps_buf[20];
                 sprintf(fps_buf, "? FPS");
-                FPSText = Text_Create(10, 30, fps_buf);
-                FPSText->on_remove = Overlay_OnFPSTextRemoval;
+                S.fps_text = Text_Create(10, 30, fps_buf);
+                S.fps_text->on_remove = Overlay_OnFPSTextRemoval;
             }
             FPSCounter = 0;
             elapsed = ClockGetMS();
         }
-    } else if (FPSText) {
-        Text_Remove(FPSText);
-        FPSText = NULL;
+    } else if (S.fps_text) {
+        Text_Remove(S.fps_text);
+        S.fps_text = NULL;
         FPSCounter = 0;
     }
 }
@@ -433,9 +437,9 @@ void Overlay_DrawGameInfo()
 void Overlay_AddPickup(int16_t object_num)
 {
     for (int i = 0; i < MAX_PICKUPS; i++) {
-        if (Pickups[i].duration <= 0) {
-            Pickups[i].duration = 75;
-            Pickups[i].sprnum = Objects[object_num].mesh_index;
+        if (S.pickups[i].duration <= 0) {
+            S.pickups[i].duration = 75;
+            S.pickups[i].sprnum = Objects[object_num].mesh_index;
             return;
         }
     }

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -306,7 +306,7 @@ void Overlay_DrawAmmoInfo()
     if (Lara.gun_status != LGS_READY || OverlayFlag <= 0
         || (SaveGame.bonus_flag & GBF_NGPLUS)) {
         if (AmmoText) {
-            T_RemovePrint(AmmoText);
+            Text_Remove(AmmoText);
             AmmoText = NULL;
         }
         return;
@@ -331,13 +331,13 @@ void Overlay_DrawAmmoInfo()
     Overlay_MakeAmmoString(ammostring);
 
     if (AmmoText) {
-        T_ChangeText(AmmoText, ammostring);
+        Text_ChangeText(AmmoText, ammostring);
     } else {
-        AmmoText = T_Print(
+        AmmoText = Text_Create(
             -screen_margin_h - text_offset_x, text_height + screen_margin_v,
             ammostring);
-        T_SetScale(AmmoText, PHD_ONE * scale, PHD_ONE * scale);
-        T_RightAlign(AmmoText, 1);
+        Text_SetScale(AmmoText, PHD_ONE * scale, PHD_ONE * scale);
+        Text_AlignRight(AmmoText, 1);
     }
 
     AmmoText->ypos = BarOffsetY[T1M_BL_TOP_RIGHT]
@@ -385,16 +385,16 @@ void Overlay_DrawFPSInfo()
         if (ClockGetMS() - elapsed >= 1000) {
             if (FPSText) {
                 sprintf(fps_buf, "%d FPS", FPSCounter);
-                T_ChangeText(FPSText, fps_buf);
+                Text_ChangeText(FPSText, fps_buf);
             } else {
                 sprintf(fps_buf, "? FPS");
-                FPSText = T_Print(10, 30, fps_buf);
+                FPSText = Text_Create(10, 30, fps_buf);
             }
             FPSCounter = 0;
             elapsed = ClockGetMS();
         }
     } else if (FPSText) {
-        T_RemovePrint(FPSText);
+        Text_Remove(FPSText);
         FPSText = NULL;
         FPSCounter = 0;
     }
@@ -412,7 +412,7 @@ void Overlay_DrawGameInfo()
     Overlay_DrawAmmoInfo();
     Overlay_DrawFPSInfo();
 
-    T_DrawText();
+    Text_Draw();
 }
 
 void Overlay_AddPickup(int16_t object_num)

--- a/src/game/pause.c
+++ b/src/game/pause.c
@@ -146,10 +146,6 @@ int8_t S_Pause()
     InvMode = INV_PAUSE_MODE;
 
     Text_RemoveAll();
-    AmmoText = NULL;
-    FPSText = NULL;
-    VersionText = NULL;
-
     S_FadeInInventory(1);
     TempVideoAdjust(GetScreenSizeIdx());
     S_SetupAboveWater(false);

--- a/src/game/pause.c
+++ b/src/game/pause.c
@@ -44,16 +44,16 @@ static int32_t PauseLoop();
 
 static void RemovePausedText()
 {
-    T_RemovePrint(PausedText);
+    Text_Remove(PausedText);
     PausedText = NULL;
 }
 
 static void DisplayPausedText()
 {
     if (PausedText == NULL) {
-        PausedText = T_Print(0, -24, GF.strings[GS_PAUSE_PAUSED]);
-        T_CentreH(PausedText, 1);
-        T_BottomAlign(PausedText, 1);
+        PausedText = Text_Create(0, -24, GF.strings[GS_PAUSE_PAUSED]);
+        Text_CentreH(PausedText, 1);
+        Text_AlignBottom(PausedText, 1);
     }
 }
 
@@ -93,7 +93,7 @@ static int32_t PauseLoop()
         S_InitialisePolyList(0);
         S_CopyBufferToScreen();
         DisplayPausedText();
-        T_DrawText();
+        Text_Draw();
         S_OutputPolyList();
         S_DumpScreen();
         S_UpdateInput();
@@ -145,7 +145,7 @@ int8_t S_Pause()
     OverlayFlag = -3;
     InvMode = INV_PAUSE_MODE;
 
-    T_RemoveAllPrints();
+    Text_RemoveAll();
     AmmoText = NULL;
     FPSText = NULL;
     VersionText = NULL;

--- a/src/game/requester.c
+++ b/src/game/requester.c
@@ -27,16 +27,16 @@ void InitRequester(REQUEST_INFO *req)
 
 void RemoveRequester(REQUEST_INFO *req)
 {
-    T_RemovePrint(req->heading);
+    Text_Remove(req->heading);
     req->heading = NULL;
-    T_RemovePrint(req->background);
+    Text_Remove(req->background);
     req->background = NULL;
-    T_RemovePrint(req->moreup);
+    Text_Remove(req->moreup);
     req->moreup = NULL;
-    T_RemovePrint(req->moredown);
+    Text_Remove(req->moredown);
     req->moredown = NULL;
     for (int i = 0; i < MAX_REQLINES; i++) {
-        T_RemovePrint(req->texts[i]);
+        Text_Remove(req->texts[i]);
         req->texts[i] = NULL;
     }
 }
@@ -57,71 +57,72 @@ int32_t DisplayRequester(REQUEST_INFO *req)
     }
 
     if (!req->heading) {
-        req->heading = T_Print(
+        req->heading = Text_Create(
             req->x, line_one_off - req->line_height - BOX_PADDING,
             req->heading_text);
-        T_CentreH(req->heading, 1);
-        T_BottomAlign(req->heading, 1);
-        T_AddBackground(req->heading, req->pix_width - 2 * BOX_BORDER, 0, 0, 0);
-        T_AddOutline(req->heading, 1);
+        Text_CentreH(req->heading, 1);
+        Text_AlignBottom(req->heading, 1);
+        Text_AddBackground(
+            req->heading, req->pix_width - 2 * BOX_BORDER, 0, 0, 0);
+        Text_AddOutline(req->heading, 1);
     }
 
     if (!req->background) {
-        req->background = T_Print(req->x, box_y, " ");
-        T_CentreH(req->background, 1);
-        T_BottomAlign(req->background, 1);
-        T_AddBackground(req->background, box_width, box_height, 0, 0);
-        T_AddOutline(req->background, 1);
+        req->background = Text_Create(req->x, box_y, " ");
+        Text_CentreH(req->background, 1);
+        Text_AlignBottom(req->background, 1);
+        Text_AddBackground(req->background, box_width, box_height, 0, 0);
+        Text_AddOutline(req->background, 1);
     }
 
     if (req->line_offset) {
         if (!req->moreup) {
             req->moreup =
-                T_Print(req->x, line_one_off - req->line_height + 2, "[");
-            T_SetScale(req->moreup, PHD_ONE * 2 / 3, PHD_ONE * 2 / 3);
-            T_CentreH(req->moreup, 1);
-            T_BottomAlign(req->moreup, 1);
+                Text_Create(req->x, line_one_off - req->line_height + 2, "[");
+            Text_SetScale(req->moreup, PHD_ONE * 2 / 3, PHD_ONE * 2 / 3);
+            Text_CentreH(req->moreup, 1);
+            Text_AlignBottom(req->moreup, 1);
         }
     } else {
-        T_RemovePrint(req->moreup);
+        Text_Remove(req->moreup);
         req->moreup = NULL;
     }
 
     if (req->items > req->vis_lines + req->line_offset) {
         if (!req->moredown) {
-            req->moredown = T_Print(req->x, edge_y - 12, "]");
-            T_SetScale(req->moredown, PHD_ONE * 2 / 3, PHD_ONE * 2 / 3);
-            T_CentreH(req->moredown, 1);
-            T_BottomAlign(req->moredown, 1);
+            req->moredown = Text_Create(req->x, edge_y - 12, "]");
+            Text_SetScale(req->moredown, PHD_ONE * 2 / 3, PHD_ONE * 2 / 3);
+            Text_CentreH(req->moredown, 1);
+            Text_AlignBottom(req->moredown, 1);
         }
     } else {
-        T_RemovePrint(req->moredown);
+        Text_Remove(req->moredown);
         req->moredown = NULL;
     }
 
     for (int i = 0; i < line_qty; i++) {
         if (!req->texts[i]) {
-            req->texts[i] = T_Print(
+            req->texts[i] = Text_Create(
                 0, line_one_off + req->line_height * i,
                 &req->item_texts[req->item_text_len * (req->line_offset + i)]);
-            T_CentreH(req->texts[i], 1);
-            T_BottomAlign(req->texts[i], 1);
+            Text_CentreH(req->texts[i], 1);
+            Text_AlignBottom(req->texts[i], 1);
         }
         if (req->line_offset + i == req->requested) {
-            T_AddBackground(
+            Text_AddBackground(
                 req->texts[i], req->pix_width - BOX_PADDING - 1 * BOX_BORDER, 0,
                 0, 0);
-            T_AddOutline(req->texts[i], 1);
+            Text_AddOutline(req->texts[i], 1);
         } else {
-            T_RemoveBackground(req->texts[i]);
-            T_RemoveOutline(req->texts[i]);
+            Text_RemoveBackground(req->texts[i]);
+            Text_RemoveOutline(req->texts[i]);
         }
     }
 
     if (req->line_offset != req->line_old_offset) {
         for (int i = 0; i < line_qty; i++) {
             if (req->texts[i]) {
-                T_ChangeText(
+                Text_ChangeText(
                     req->texts[i],
                     &req->item_texts
                          [req->item_text_len * (req->line_offset + i)]);
@@ -172,7 +173,7 @@ int32_t DisplayRequester(REQUEST_INFO *req)
 
 void SetRequesterHeading(REQUEST_INFO *req, const char *string)
 {
-    T_RemovePrint(req->heading);
+    Text_Remove(req->heading);
     req->heading = NULL;
 
     if (string) {

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -115,7 +115,6 @@ int32_t InitialiseLevel(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
     InitialiseLOTArray();
 
     InitColours();
-    Text_Init();
     Overlay_Init();
 
     HealthBarTimer = 100;

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -96,7 +96,7 @@ int32_t InitialiseLevel(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
         CurrentLevel = level_num;
     }
 
-    T_RemoveAllPrints();
+    Text_RemoveAll();
     AmmoText = NULL;
     FPSText = NULL;
     VersionText = NULL;
@@ -120,7 +120,7 @@ int32_t InitialiseLevel(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
     InitialiseLOTArray();
 
     InitColours();
-    T_InitPrint();
+    Text_Init();
     Overlay_Init();
 
     HealthBarTimer = 100;

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -97,14 +97,9 @@ int32_t InitialiseLevel(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
     }
 
     Text_RemoveAll();
-    AmmoText = NULL;
-    FPSText = NULL;
-    VersionText = NULL;
-
     InitialiseGameFlags();
 
     Lara.item_number = NO_ITEM;
-
     S_InitialiseScreen();
 
     if (!S_LoadLevel(CurrentLevel)) {

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -145,12 +145,12 @@ void T_SetScale(TEXTSTRING *textstring, int32_t scale_h, int32_t scale_v)
     textstring->scale_v = scale_v;
 }
 
-void T_FlashText(TEXTSTRING *textstring, int16_t b, int16_t rate)
+void T_FlashText(TEXTSTRING *textstring, bool enable, int16_t rate)
 {
     if (!textstring) {
         return;
     }
-    if (b) {
+    if (enable) {
         textstring->flags |= TF_FLASH;
         textstring->flash_rate = rate;
         textstring->flash_count = rate;
@@ -180,7 +180,7 @@ void T_RemoveBackground(TEXTSTRING *textstring)
     textstring->flags &= ~TF_BGND;
 }
 
-void T_AddOutline(TEXTSTRING *textstring, int16_t b)
+void T_AddOutline(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
@@ -196,48 +196,48 @@ void T_RemoveOutline(TEXTSTRING *textstring)
     textstring->flags &= ~TF_OUTLINE;
 }
 
-void T_CentreH(TEXTSTRING *textstring, int16_t b)
+void T_CentreH(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
     }
-    if (b) {
+    if (enable) {
         textstring->flags |= TF_CENTRE_H;
     } else {
         textstring->flags &= ~TF_CENTRE_H;
     }
 }
 
-void T_CentreV(TEXTSTRING *textstring, int16_t b)
+void T_CentreV(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
     }
-    if (b) {
+    if (enable) {
         textstring->flags |= TF_CENTRE_V;
     } else {
         textstring->flags &= ~TF_CENTRE_V;
     }
 }
 
-void T_RightAlign(TEXTSTRING *textstring, int16_t b)
+void T_RightAlign(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
     }
-    if (b) {
+    if (enable) {
         textstring->flags |= TF_RIGHT;
     } else {
         textstring->flags &= ~TF_RIGHT;
     }
 }
 
-void T_BottomAlign(TEXTSTRING *textstring, int16_t b)
+void T_BottomAlign(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
     }
-    if (b) {
+    if (enable) {
         textstring->flags |= TF_BOTTOM;
     } else {
         textstring->flags &= ~TF_BOTTOM;

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -6,6 +6,7 @@
 #include "specific/clock.h"
 #include "specific/frontend.h"
 #include "specific/output.h"
+#include "util.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -57,16 +58,6 @@ static int8_t Text_ASCIIMap[95] = {
 };
 
 static void Text_DrawText(TEXTSTRING *textstring);
-static int Text_GetStringLen(const char *string);
-
-static int Text_GetStringLen(const char *string)
-{
-    int len = 1;
-    while (*string++) {
-        len++;
-    }
-    return len;
-}
 
 void Text_Init()
 {
@@ -98,20 +89,13 @@ TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
         return NULL;
     }
 
-    int length = Text_GetStringLen(string);
-    if (length > TEXT_MAX_STRING_SIZE) {
-        length = TEXT_MAX_STRING_SIZE;
-    }
-
+    result->string = S.text_strings[n];
     result->pos.x = x;
     result->pos.y = y;
     result->letter_spacing = 1;
     result->word_spacing = 6;
     result->scale.h = PHD_ONE;
     result->scale.v = PHD_ONE;
-
-    result->string = S.text_strings[n];
-    strncpy(result->string, string, length);
 
     result->flags.all = 0;
     result->flags.active = 1;
@@ -120,6 +104,8 @@ TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
     result->bgnd_size.y = 0;
     result->bgnd_off.x = 0;
     result->bgnd_off.y = 0;
+
+    Text_ChangeText(result, string);
 
     S.textstring_count++;
 
@@ -134,8 +120,10 @@ void Text_ChangeText(TEXTSTRING *textstring, const char *string)
     if (!textstring->flags.active) {
         return;
     }
-    strncpy(textstring->string, string, TEXT_MAX_STRING_SIZE);
-    if (Text_GetStringLen(string) > TEXT_MAX_STRING_SIZE) {
+    size_t length = strlen(string) + 1;
+    CLAMPG(length, TEXT_MAX_STRING_SIZE);
+    strncpy(textstring->string, string, length);
+    if (length >= TEXT_MAX_STRING_SIZE) {
         textstring->string[TEXT_MAX_STRING_SIZE - 1] = '\0';
     }
 }

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -52,7 +52,10 @@ static int8_t TextRemapASCII[95] = {
     100 /*{*/, 101 /*|*/, 102 /*}*/, 67 /*~*/
 };
 
-int Text_GetStringLen(const char *string)
+static void Text_DrawText(TEXTSTRING *textstring);
+static int Text_GetStringLen(const char *string);
+
+static int Text_GetStringLen(const char *string)
 {
     int len = 1;
     while (*string++) {
@@ -299,12 +302,12 @@ void Text_Draw()
     for (int i = 0; i < MAX_TEXT_STRINGS; i++) {
         TEXTSTRING *textstring = &TextInfoTable[i];
         if (textstring->flags & TF_ACTIVE) {
-            Text_DrawThisText(textstring);
+            Text_DrawText(textstring);
         }
     }
 }
 
-void Text_DrawThisText(TEXTSTRING *textstring)
+static void Text_DrawText(TEXTSTRING *textstring)
 {
     int sx, sy, sh, sv;
     if (textstring->flags & TF_FLASH) {

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -105,6 +105,8 @@ TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
     result->bgnd_off.x = 0;
     result->bgnd_off.y = 0;
 
+    result->on_remove = NULL;
+
     Text_ChangeText(result, string);
 
     S.textstring_count++;
@@ -260,6 +262,9 @@ void Text_Remove(TEXTSTRING *textstring)
         return;
     }
     if (textstring->flags.active) {
+        if (textstring->on_remove) {
+            textstring->on_remove(textstring);
+        }
         textstring->flags.active = 0;
         S.textstring_count--;
     }
@@ -267,6 +272,12 @@ void Text_Remove(TEXTSTRING *textstring)
 
 void Text_RemoveAll()
 {
+    for (int i = 0; i < TEXT_MAX_STRINGS; i++) {
+        TEXTSTRING *textstring = &S.textstring_table[i];
+        if (textstring->flags.active) {
+            Text_Remove(textstring);
+        }
+    }
     Text_Init();
 }
 

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -52,7 +52,7 @@ static int8_t TextRemapASCII[95] = {
     100 /*{*/, 101 /*|*/, 102 /*}*/, 67 /*~*/
 };
 
-int T_GetStringLen(const char *string)
+int Text_GetStringLen(const char *string)
 {
     int len = 1;
     while (*string++) {
@@ -61,7 +61,7 @@ int T_GetStringLen(const char *string)
     return len;
 }
 
-void T_InitPrint()
+void Text_Init()
 {
     for (int i = 0; i < MAX_TEXT_STRINGS; i++) {
         TextInfoTable[i].flags = 0;
@@ -69,7 +69,7 @@ void T_InitPrint()
     TextStringCount = 0;
 }
 
-TEXTSTRING *T_Print(int16_t x, int16_t y, const char *string)
+TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
 {
     if (TextStringCount == MAX_TEXT_STRINGS) {
         return NULL;
@@ -91,7 +91,7 @@ TEXTSTRING *T_Print(int16_t x, int16_t y, const char *string)
         return NULL;
     }
 
-    int length = T_GetStringLen(string);
+    int length = Text_GetStringLen(string);
     if (length >= MAX_STRING_SIZE) {
         length = MAX_STRING_SIZE - 1;
     }
@@ -122,7 +122,7 @@ TEXTSTRING *T_Print(int16_t x, int16_t y, const char *string)
     return result;
 }
 
-void T_ChangeText(TEXTSTRING *textstring, const char *string)
+void Text_ChangeText(TEXTSTRING *textstring, const char *string)
 {
     if (!textstring) {
         return;
@@ -131,12 +131,12 @@ void T_ChangeText(TEXTSTRING *textstring, const char *string)
         return;
     }
     strncpy(textstring->string, string, MAX_STRING_SIZE);
-    if (T_GetStringLen(string) > MAX_STRING_SIZE) {
+    if (Text_GetStringLen(string) > MAX_STRING_SIZE) {
         textstring->string[MAX_STRING_SIZE - 1] = '\0';
     }
 }
 
-void T_SetScale(TEXTSTRING *textstring, int32_t scale_h, int32_t scale_v)
+void Text_SetScale(TEXTSTRING *textstring, int32_t scale_h, int32_t scale_v)
 {
     if (!textstring) {
         return;
@@ -145,7 +145,7 @@ void T_SetScale(TEXTSTRING *textstring, int32_t scale_h, int32_t scale_v)
     textstring->scale_v = scale_v;
 }
 
-void T_FlashText(TEXTSTRING *textstring, bool enable, int16_t rate)
+void Text_Flash(TEXTSTRING *textstring, bool enable, int16_t rate)
 {
     if (!textstring) {
         return;
@@ -159,7 +159,7 @@ void T_FlashText(TEXTSTRING *textstring, bool enable, int16_t rate)
     }
 }
 
-void T_AddBackground(
+void Text_AddBackground(
     TEXTSTRING *textstring, int16_t w, int16_t h, int16_t x, int16_t y)
 {
     if (!textstring) {
@@ -172,7 +172,7 @@ void T_AddBackground(
     textstring->bgnd_off_y = y;
 }
 
-void T_RemoveBackground(TEXTSTRING *textstring)
+void Text_RemoveBackground(TEXTSTRING *textstring)
 {
     if (!textstring) {
         return;
@@ -180,7 +180,7 @@ void T_RemoveBackground(TEXTSTRING *textstring)
     textstring->flags &= ~TF_BGND;
 }
 
-void T_AddOutline(TEXTSTRING *textstring, bool enable)
+void Text_AddOutline(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
@@ -188,7 +188,7 @@ void T_AddOutline(TEXTSTRING *textstring, bool enable)
     textstring->flags |= TF_OUTLINE;
 }
 
-void T_RemoveOutline(TEXTSTRING *textstring)
+void Text_RemoveOutline(TEXTSTRING *textstring)
 {
     if (!textstring) {
         return;
@@ -196,7 +196,7 @@ void T_RemoveOutline(TEXTSTRING *textstring)
     textstring->flags &= ~TF_OUTLINE;
 }
 
-void T_CentreH(TEXTSTRING *textstring, bool enable)
+void Text_CentreH(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
@@ -208,7 +208,7 @@ void T_CentreH(TEXTSTRING *textstring, bool enable)
     }
 }
 
-void T_CentreV(TEXTSTRING *textstring, bool enable)
+void Text_CentreV(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
@@ -220,7 +220,7 @@ void T_CentreV(TEXTSTRING *textstring, bool enable)
     }
 }
 
-void T_RightAlign(TEXTSTRING *textstring, bool enable)
+void Text_AlignRight(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
@@ -232,7 +232,7 @@ void T_RightAlign(TEXTSTRING *textstring, bool enable)
     }
 }
 
-void T_BottomAlign(TEXTSTRING *textstring, bool enable)
+void Text_AlignBottom(TEXTSTRING *textstring, bool enable)
 {
     if (!textstring) {
         return;
@@ -244,7 +244,7 @@ void T_BottomAlign(TEXTSTRING *textstring, bool enable)
     }
 }
 
-int32_t T_GetTextWidth(TEXTSTRING *textstring)
+int32_t Text_GetWidth(TEXTSTRING *textstring)
 {
     if (!textstring) {
         return 0;
@@ -278,7 +278,7 @@ int32_t T_GetTextWidth(TEXTSTRING *textstring)
     return width;
 }
 
-void T_RemovePrint(TEXTSTRING *textstring)
+void Text_Remove(TEXTSTRING *textstring)
 {
     if (!textstring) {
         return;
@@ -289,22 +289,22 @@ void T_RemovePrint(TEXTSTRING *textstring)
     }
 }
 
-void T_RemoveAllPrints()
+void Text_RemoveAll()
 {
-    T_InitPrint();
+    Text_Init();
 }
 
-void T_DrawText()
+void Text_Draw()
 {
     for (int i = 0; i < MAX_TEXT_STRINGS; i++) {
         TEXTSTRING *textstring = &TextInfoTable[i];
         if (textstring->flags & TF_ACTIVE) {
-            T_DrawThisText(textstring);
+            Text_DrawThisText(textstring);
         }
     }
 }
 
-void T_DrawThisText(TEXTSTRING *textstring)
+void Text_DrawThisText(TEXTSTRING *textstring)
 {
     int sx, sy, sh, sv;
     if (textstring->flags & TF_FLASH) {
@@ -319,7 +319,7 @@ void T_DrawThisText(TEXTSTRING *textstring)
     char *string = textstring->string;
     int32_t x = textstring->xpos;
     int32_t y = textstring->ypos;
-    int32_t textwidth = T_GetTextWidth(textstring);
+    int32_t textwidth = Text_GetWidth(textstring);
 
     if (textstring->flags & TF_CENTRE_H) {
         x += (GetRenderWidthDownscaled() - textwidth) / 2;

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -67,7 +67,7 @@ static int Text_GetStringLen(const char *string)
 void Text_Init()
 {
     for (int i = 0; i < MAX_TEXT_STRINGS; i++) {
-        TextInfoTable[i].flags = 0;
+        TextInfoTable[i].flags.all = 0;
     }
     TextStringCount = 0;
 }
@@ -81,7 +81,7 @@ TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
     TEXTSTRING *result = &TextInfoTable[0];
     int n;
     for (n = 0; n < MAX_TEXT_STRINGS; n++) {
-        if (!(result->flags & TF_ACTIVE)) {
+        if (!result->flags.active) {
             break;
         }
         result++;
@@ -99,26 +99,23 @@ TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
         length = MAX_STRING_SIZE - 1;
     }
 
-    result->xpos = x;
-    result->ypos = y;
+    result->pos.x = x;
+    result->pos.y = y;
     result->letter_spacing = 1;
     result->word_spacing = 6;
-    result->scale_h = PHD_ONE;
-    result->scale_v = PHD_ONE;
+    result->scale.h = PHD_ONE;
+    result->scale.v = PHD_ONE;
 
     result->string = TextStrings[n];
     memcpy(result->string, string, length + 1);
 
-    result->flags = TF_ACTIVE;
-    result->text_flags = 0;
-    result->outl_flags = 0;
-    result->bgnd_flags = 0;
+    result->flags.all = 0;
+    result->flags.active = 1;
 
-    result->bgnd_size_x = 0;
-    result->bgnd_size_y = 0;
-    result->bgnd_off_x = 0;
-    result->bgnd_off_y = 0;
-    result->bgnd_off_z = 0;
+    result->bgnd_size.x = 0;
+    result->bgnd_size.y = 0;
+    result->bgnd_off.x = 0;
+    result->bgnd_off.y = 0;
 
     TextStringCount++;
 
@@ -130,7 +127,7 @@ void Text_ChangeText(TEXTSTRING *textstring, const char *string)
     if (!textstring) {
         return;
     }
-    if (!(textstring->flags & TF_ACTIVE)) {
+    if (!textstring->flags.active) {
         return;
     }
     strncpy(textstring->string, string, MAX_STRING_SIZE);
@@ -144,8 +141,8 @@ void Text_SetScale(TEXTSTRING *textstring, int32_t scale_h, int32_t scale_v)
     if (!textstring) {
         return;
     }
-    textstring->scale_h = scale_h;
-    textstring->scale_v = scale_v;
+    textstring->scale.h = scale_h;
+    textstring->scale.v = scale_v;
 }
 
 void Text_Flash(TEXTSTRING *textstring, bool enable, int16_t rate)
@@ -154,11 +151,11 @@ void Text_Flash(TEXTSTRING *textstring, bool enable, int16_t rate)
         return;
     }
     if (enable) {
-        textstring->flags |= TF_FLASH;
-        textstring->flash_rate = rate;
-        textstring->flash_count = rate;
+        textstring->flags.flash = 1;
+        textstring->flash.rate = rate;
+        textstring->flash.count = rate;
     } else {
-        textstring->flags &= ~TF_FLASH;
+        textstring->flags.flash = 0;
     }
 }
 
@@ -168,11 +165,11 @@ void Text_AddBackground(
     if (!textstring) {
         return;
     }
-    textstring->flags |= TF_BGND;
-    textstring->bgnd_size_x = w;
-    textstring->bgnd_size_y = h;
-    textstring->bgnd_off_x = x;
-    textstring->bgnd_off_y = y;
+    textstring->flags.background = 1;
+    textstring->bgnd_size.x = w;
+    textstring->bgnd_size.y = h;
+    textstring->bgnd_off.x = x;
+    textstring->bgnd_off.y = y;
 }
 
 void Text_RemoveBackground(TEXTSTRING *textstring)
@@ -180,7 +177,7 @@ void Text_RemoveBackground(TEXTSTRING *textstring)
     if (!textstring) {
         return;
     }
-    textstring->flags &= ~TF_BGND;
+    textstring->flags.background = 0;
 }
 
 void Text_AddOutline(TEXTSTRING *textstring, bool enable)
@@ -188,7 +185,7 @@ void Text_AddOutline(TEXTSTRING *textstring, bool enable)
     if (!textstring) {
         return;
     }
-    textstring->flags |= TF_OUTLINE;
+    textstring->flags.outline = 1;
 }
 
 void Text_RemoveOutline(TEXTSTRING *textstring)
@@ -196,7 +193,7 @@ void Text_RemoveOutline(TEXTSTRING *textstring)
     if (!textstring) {
         return;
     }
-    textstring->flags &= ~TF_OUTLINE;
+    textstring->flags.outline = 0;
 }
 
 void Text_CentreH(TEXTSTRING *textstring, bool enable)
@@ -204,11 +201,7 @@ void Text_CentreH(TEXTSTRING *textstring, bool enable)
     if (!textstring) {
         return;
     }
-    if (enable) {
-        textstring->flags |= TF_CENTRE_H;
-    } else {
-        textstring->flags &= ~TF_CENTRE_H;
-    }
+    textstring->flags.centre_h = enable;
 }
 
 void Text_CentreV(TEXTSTRING *textstring, bool enable)
@@ -216,11 +209,7 @@ void Text_CentreV(TEXTSTRING *textstring, bool enable)
     if (!textstring) {
         return;
     }
-    if (enable) {
-        textstring->flags |= TF_CENTRE_V;
-    } else {
-        textstring->flags &= ~TF_CENTRE_V;
-    }
+    textstring->flags.centre_v = enable;
 }
 
 void Text_AlignRight(TEXTSTRING *textstring, bool enable)
@@ -228,11 +217,7 @@ void Text_AlignRight(TEXTSTRING *textstring, bool enable)
     if (!textstring) {
         return;
     }
-    if (enable) {
-        textstring->flags |= TF_RIGHT;
-    } else {
-        textstring->flags &= ~TF_RIGHT;
-    }
+    textstring->flags.right = enable;
 }
 
 void Text_AlignBottom(TEXTSTRING *textstring, bool enable)
@@ -240,11 +225,7 @@ void Text_AlignBottom(TEXTSTRING *textstring, bool enable)
     if (!textstring) {
         return;
     }
-    if (enable) {
-        textstring->flags |= TF_BOTTOM;
-    } else {
-        textstring->flags &= ~TF_BOTTOM;
-    }
+    textstring->flags.bottom = enable;
 }
 
 int32_t Text_GetWidth(TEXTSTRING *textstring)
@@ -260,7 +241,7 @@ int32_t Text_GetWidth(TEXTSTRING *textstring)
         }
 
         if (letter == 32) {
-            width += textstring->word_spacing * textstring->scale_h / PHD_ONE;
+            width += textstring->word_spacing * textstring->scale.h / PHD_ONE;
             continue;
         }
 
@@ -273,7 +254,7 @@ int32_t Text_GetWidth(TEXTSTRING *textstring)
         }
 
         width += ((TextSpacing[(uint8_t)letter] + textstring->letter_spacing)
-                  * textstring->scale_h)
+                  * textstring->scale.h)
             / PHD_ONE;
     }
     width -= textstring->letter_spacing;
@@ -286,8 +267,8 @@ void Text_Remove(TEXTSTRING *textstring)
     if (!textstring) {
         return;
     }
-    if (textstring->flags & TF_ACTIVE) {
-        textstring->flags &= ~TF_ACTIVE;
+    if (textstring->flags.active) {
+        textstring->flags.active = 0;
         TextStringCount--;
     }
 }
@@ -301,7 +282,7 @@ void Text_Draw()
 {
     for (int i = 0; i < MAX_TEXT_STRINGS; i++) {
         TEXTSTRING *textstring = &TextInfoTable[i];
-        if (textstring->flags & TF_ACTIVE) {
+        if (textstring->flags.active) {
             Text_DrawText(textstring);
         }
     }
@@ -310,35 +291,35 @@ void Text_Draw()
 static void Text_DrawText(TEXTSTRING *textstring)
 {
     int sx, sy, sh, sv;
-    if (textstring->flags & TF_FLASH) {
-        textstring->flash_count -= (int16_t)Camera.number_frames;
-        if (textstring->flash_count <= -textstring->flash_rate) {
-            textstring->flash_count = textstring->flash_rate;
-        } else if (textstring->flash_count < 0) {
+    if (textstring->flags.flash) {
+        textstring->flash.count -= (int16_t)Camera.number_frames;
+        if (textstring->flash.count <= -textstring->flash.rate) {
+            textstring->flash.count = textstring->flash.rate;
+        } else if (textstring->flash.count < 0) {
             return;
         }
     }
 
     char *string = textstring->string;
-    int32_t x = textstring->xpos;
-    int32_t y = textstring->ypos;
+    int32_t x = textstring->pos.x;
+    int32_t y = textstring->pos.y;
     int32_t textwidth = Text_GetWidth(textstring);
 
-    if (textstring->flags & TF_CENTRE_H) {
+    if (textstring->flags.centre_h) {
         x += (GetRenderWidthDownscaled() - textwidth) / 2;
-    } else if (textstring->flags & TF_RIGHT) {
+    } else if (textstring->flags.right) {
         x += GetRenderWidthDownscaled() - textwidth;
     }
 
-    if (textstring->flags & TF_CENTRE_V) {
+    if (textstring->flags.centre_v) {
         y += GetRenderHeightDownscaled() / 2;
-    } else if (textstring->flags & TF_BOTTOM) {
+    } else if (textstring->flags.bottom) {
         y += GetRenderHeightDownscaled();
     }
 
-    int32_t bxpos = textstring->bgnd_off_x + x - TEXT_BOX_OFFSET;
+    int32_t bxpos = textstring->bgnd_off.x + x - TEXT_BOX_OFFSET;
     int32_t bypos =
-        textstring->bgnd_off_y + y - TEXT_BOX_OFFSET * 2 - TEXT_HEIGHT;
+        textstring->bgnd_off.y + y - TEXT_BOX_OFFSET * 2 - TEXT_HEIGHT;
 
     int32_t letter = '\0';
     while (*string) {
@@ -348,7 +329,7 @@ static void Text_DrawText(TEXTSTRING *textstring)
         }
 
         if (letter == ' ') {
-            x += (textstring->word_spacing * textstring->scale_h) / PHD_ONE;
+            x += (textstring->word_spacing * textstring->scale.h) / PHD_ONE;
             continue;
         }
 
@@ -363,40 +344,40 @@ static void Text_DrawText(TEXTSTRING *textstring)
 
         sx = GetRenderScale(x);
         sy = GetRenderScale(y);
-        sh = GetRenderScale(textstring->scale_h);
-        sv = GetRenderScale(textstring->scale_v);
+        sh = GetRenderScale(textstring->scale.h);
+        sv = GetRenderScale(textstring->scale.v);
 
         S_DrawScreenSprite2d(
             sx, sy, 0, sh, sv, Objects[O_ALPHABET].mesh_index + sprite_num,
-            16 << 8, textstring->text_flags, 0);
+            16 << 8, 0, 0);
 
         if (letter == '(' || letter == ')' || letter == '$' || letter == '~') {
             continue;
         }
 
         x += (((int32_t)textstring->letter_spacing + TextSpacing[sprite_num])
-              * textstring->scale_h)
+              * textstring->scale.h)
             / PHD_ONE;
     }
 
     int32_t bwidth = 0;
     int32_t bheight = 0;
-    if ((textstring->flags & TF_BGND) || (textstring->flags & TF_OUTLINE)) {
-        if (textstring->bgnd_size_x) {
+    if (textstring->flags.background || textstring->flags.outline) {
+        if (textstring->bgnd_size.x) {
             bxpos += textwidth / 2;
-            bxpos -= textstring->bgnd_size_x / 2;
-            bwidth = textstring->bgnd_size_x + TEXT_BOX_OFFSET * 2;
+            bxpos -= textstring->bgnd_size.x / 2;
+            bwidth = textstring->bgnd_size.x + TEXT_BOX_OFFSET * 2;
         } else {
             bwidth = textwidth + TEXT_BOX_OFFSET * 2;
         }
-        if (textstring->bgnd_size_y) {
-            bheight = textstring->bgnd_size_y;
+        if (textstring->bgnd_size.y) {
+            bheight = textstring->bgnd_size.y;
         } else {
             bheight = TEXT_HEIGHT + 7;
         }
     }
 
-    if (textstring->flags & TF_BGND) {
+    if (textstring->flags.background) {
         sx = GetRenderScale(bxpos);
         sy = GetRenderScale(bypos);
         sh = GetRenderScale(bwidth);
@@ -405,7 +386,7 @@ static void Text_DrawText(TEXTSTRING *textstring)
         S_DrawScreenFBox(sx, sy, sh, sv);
     }
 
-    if (textstring->flags & TF_OUTLINE) {
+    if (textstring->flags.outline) {
         sx = GetRenderScale(bxpos);
         sy = GetRenderScale(bypos);
         sh = GetRenderScale(bwidth);

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -11,11 +11,13 @@
 #include <string.h>
 
 #define TEXT_BOX_OFFSET 2
+#define TEXT_MAX_STRING_SIZE 100
+#define TEXT_MAX_STRINGS 64
 
 static struct {
     int16_t textstring_count;
-    TEXTSTRING textstring_table[MAX_TEXT_STRINGS];
-    char text_strings[MAX_TEXT_STRINGS][MAX_STRING_SIZE];
+    TEXTSTRING textstring_table[TEXT_MAX_STRINGS];
+    char text_strings[TEXT_MAX_STRINGS][TEXT_MAX_STRING_SIZE];
 } S = { 0 };
 
 static int8_t Text_Spacing[110] = {
@@ -68,7 +70,7 @@ static int Text_GetStringLen(const char *string)
 
 void Text_Init()
 {
-    for (int i = 0; i < MAX_TEXT_STRINGS; i++) {
+    for (int i = 0; i < TEXT_MAX_STRINGS; i++) {
         S.textstring_table[i].flags.all = 0;
     }
     S.textstring_count = 0;
@@ -76,19 +78,19 @@ void Text_Init()
 
 TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
 {
-    if (S.textstring_count == MAX_TEXT_STRINGS) {
+    if (S.textstring_count == TEXT_MAX_STRINGS) {
         return NULL;
     }
 
     TEXTSTRING *result = &S.textstring_table[0];
     int n;
-    for (n = 0; n < MAX_TEXT_STRINGS; n++) {
+    for (n = 0; n < TEXT_MAX_STRINGS; n++) {
         if (!result->flags.active) {
             break;
         }
         result++;
     }
-    if (n >= MAX_TEXT_STRINGS) {
+    if (n >= TEXT_MAX_STRINGS) {
         return NULL;
     }
 
@@ -97,8 +99,8 @@ TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
     }
 
     int length = Text_GetStringLen(string);
-    if (length >= MAX_STRING_SIZE) {
-        length = MAX_STRING_SIZE - 1;
+    if (length > TEXT_MAX_STRING_SIZE) {
+        length = TEXT_MAX_STRING_SIZE;
     }
 
     result->pos.x = x;
@@ -109,7 +111,7 @@ TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
     result->scale.v = PHD_ONE;
 
     result->string = S.text_strings[n];
-    memcpy(result->string, string, length + 1);
+    strncpy(result->string, string, length);
 
     result->flags.all = 0;
     result->flags.active = 1;
@@ -132,9 +134,9 @@ void Text_ChangeText(TEXTSTRING *textstring, const char *string)
     if (!textstring->flags.active) {
         return;
     }
-    strncpy(textstring->string, string, MAX_STRING_SIZE);
-    if (Text_GetStringLen(string) > MAX_STRING_SIZE) {
-        textstring->string[MAX_STRING_SIZE - 1] = '\0';
+    strncpy(textstring->string, string, TEXT_MAX_STRING_SIZE);
+    if (Text_GetStringLen(string) > TEXT_MAX_STRING_SIZE) {
+        textstring->string[TEXT_MAX_STRING_SIZE - 1] = '\0';
     }
 }
 
@@ -282,7 +284,7 @@ void Text_RemoveAll()
 
 void Text_Draw()
 {
-    for (int i = 0; i < MAX_TEXT_STRINGS; i++) {
+    for (int i = 0; i < TEXT_MAX_STRINGS; i++) {
         TEXTSTRING *textstring = &S.textstring_table[i];
         if (textstring->flags.active) {
             Text_DrawText(textstring);

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -12,11 +12,13 @@
 
 #define TEXT_BOX_OFFSET 2
 
-static int16_t TextStringCount = 0;
-static TEXTSTRING TextInfoTable[MAX_TEXT_STRINGS] = { 0 };
-static char TextStrings[MAX_TEXT_STRINGS][MAX_STRING_SIZE] = { 0 };
+static struct {
+    int16_t textstring_count;
+    TEXTSTRING textstring_table[MAX_TEXT_STRINGS];
+    char text_strings[MAX_TEXT_STRINGS][MAX_STRING_SIZE];
+} S = { 0 };
 
-static int8_t TextSpacing[110] = {
+static int8_t Text_Spacing[110] = {
     14 /*A*/,  11 /*B*/, 11 /*C*/, 11 /*D*/, 11 /*E*/, 11 /*F*/, 11 /*G*/,
     13 /*H*/,  8 /*I*/,  11 /*J*/, 12 /*K*/, 11 /*L*/, 13 /*M*/, 13 /*N*/,
     12 /*O*/,  11 /*P*/, 12 /*Q*/, 12 /*R*/, 11 /*S*/, 12 /*T*/, 13 /*U*/,
@@ -35,7 +37,7 @@ static int8_t TextSpacing[110] = {
     8,         8,        8,        8,        8
 };
 
-static int8_t TextRemapASCII[95] = {
+static int8_t Text_ASCIIMap[95] = {
     0 /* */,   64 /*!*/,  66 /*"*/,  78 /*#*/, 77 /*$*/, 74 /*%*/, 78 /*&*/,
     79 /*'*/,  69 /*(*/,  70 /*)*/,  92 /***/, 72 /*+*/, 63 /*,*/, 71 /*-*/,
     62 /*.*/,  68 /**/,   52 /*0*/,  53 /*1*/, 54 /*2*/, 55 /*3*/, 56 /*4*/,
@@ -67,18 +69,18 @@ static int Text_GetStringLen(const char *string)
 void Text_Init()
 {
     for (int i = 0; i < MAX_TEXT_STRINGS; i++) {
-        TextInfoTable[i].flags.all = 0;
+        S.textstring_table[i].flags.all = 0;
     }
-    TextStringCount = 0;
+    S.textstring_count = 0;
 }
 
 TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
 {
-    if (TextStringCount == MAX_TEXT_STRINGS) {
+    if (S.textstring_count == MAX_TEXT_STRINGS) {
         return NULL;
     }
 
-    TEXTSTRING *result = &TextInfoTable[0];
+    TEXTSTRING *result = &S.textstring_table[0];
     int n;
     for (n = 0; n < MAX_TEXT_STRINGS; n++) {
         if (!result->flags.active) {
@@ -106,7 +108,7 @@ TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
     result->scale.h = PHD_ONE;
     result->scale.v = PHD_ONE;
 
-    result->string = TextStrings[n];
+    result->string = S.text_strings[n];
     memcpy(result->string, string, length + 1);
 
     result->flags.all = 0;
@@ -117,7 +119,7 @@ TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string)
     result->bgnd_off.x = 0;
     result->bgnd_off.y = 0;
 
-    TextStringCount++;
+    S.textstring_count++;
 
     return result;
 }
@@ -246,14 +248,14 @@ int32_t Text_GetWidth(TEXTSTRING *textstring)
         }
 
         if (letter >= 16) {
-            letter = TextRemapASCII[letter - 32];
+            letter = Text_ASCIIMap[letter - 32];
         } else if (letter >= 11) {
             letter = letter + 91;
         } else {
             letter = letter + 81;
         }
 
-        width += ((TextSpacing[(uint8_t)letter] + textstring->letter_spacing)
+        width += ((Text_Spacing[(uint8_t)letter] + textstring->letter_spacing)
                   * textstring->scale.h)
             / PHD_ONE;
     }
@@ -269,7 +271,7 @@ void Text_Remove(TEXTSTRING *textstring)
     }
     if (textstring->flags.active) {
         textstring->flags.active = 0;
-        TextStringCount--;
+        S.textstring_count--;
     }
 }
 
@@ -281,7 +283,7 @@ void Text_RemoveAll()
 void Text_Draw()
 {
     for (int i = 0; i < MAX_TEXT_STRINGS; i++) {
-        TEXTSTRING *textstring = &TextInfoTable[i];
+        TEXTSTRING *textstring = &S.textstring_table[i];
         if (textstring->flags.active) {
             Text_DrawText(textstring);
         }
@@ -335,7 +337,7 @@ static void Text_DrawText(TEXTSTRING *textstring)
 
         int32_t sprite_num = letter;
         if (letter >= 16) {
-            sprite_num = TextRemapASCII[letter - 32];
+            sprite_num = Text_ASCIIMap[letter - 32];
         } else if (letter >= 11) {
             sprite_num = letter + 91;
         } else {
@@ -355,7 +357,7 @@ static void Text_DrawText(TEXTSTRING *textstring)
             continue;
         }
 
-        x += (((int32_t)textstring->letter_spacing + TextSpacing[sprite_num])
+        x += (((int32_t)textstring->letter_spacing + Text_Spacing[sprite_num])
               * textstring->scale.h)
             / PHD_ONE;
     }

--- a/src/game/text.h
+++ b/src/game/text.h
@@ -6,24 +6,24 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void T_InitPrint();
-TEXTSTRING *T_Print(int16_t x, int16_t y, const char *string);
-void T_ChangeText(TEXTSTRING *textstring, const char *string);
-void T_SetScale(TEXTSTRING *textstring, int32_t scale_h, int32_t scale_v);
-void T_FlashText(TEXTSTRING *textstring, bool enable, int16_t rate);
-void T_AddBackground(
+void Text_Init();
+TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string);
+void Text_ChangeText(TEXTSTRING *textstring, const char *string);
+void Text_SetScale(TEXTSTRING *textstring, int32_t scale_h, int32_t scale_v);
+void Text_Flash(TEXTSTRING *textstring, bool enable, int16_t rate);
+void Text_AddBackground(
     TEXTSTRING *textstring, int16_t w, int16_t h, int16_t x, int16_t y);
-void T_RemoveBackground(TEXTSTRING *textstring);
-void T_AddOutline(TEXTSTRING *textstring, bool enable);
-void T_RemoveOutline(TEXTSTRING *textstring);
-void T_CentreH(TEXTSTRING *textstring, bool enable);
-void T_CentreV(TEXTSTRING *textstring, bool enable);
-void T_RightAlign(TEXTSTRING *textstring, bool enable);
-void T_BottomAlign(TEXTSTRING *textstring, bool enable);
-int32_t T_GetTextWidth(TEXTSTRING *textstring);
-void T_RemovePrint(TEXTSTRING *textstring);
-void T_RemoveAllPrints();
-void T_DrawText();
-void T_DrawThisText(TEXTSTRING *textstring);
+void Text_RemoveBackground(TEXTSTRING *textstring);
+void Text_AddOutline(TEXTSTRING *textstring, bool enable);
+void Text_RemoveOutline(TEXTSTRING *textstring);
+void Text_CentreH(TEXTSTRING *textstring, bool enable);
+void Text_CentreV(TEXTSTRING *textstring, bool enable);
+void Text_AlignRight(TEXTSTRING *textstring, bool enable);
+void Text_AlignBottom(TEXTSTRING *textstring, bool enable);
+int32_t Text_GetWidth(TEXTSTRING *textstring);
+void Text_Remove(TEXTSTRING *textstring);
+void Text_RemoveAll();
+void Text_Draw();
+void Text_DrawThisText(TEXTSTRING *textstring);
 
 #endif

--- a/src/game/text.h
+++ b/src/game/text.h
@@ -3,22 +3,23 @@
 
 #include "global/types.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 void T_InitPrint();
 TEXTSTRING *T_Print(int16_t x, int16_t y, const char *string);
 void T_ChangeText(TEXTSTRING *textstring, const char *string);
 void T_SetScale(TEXTSTRING *textstring, int32_t scale_h, int32_t scale_v);
-void T_FlashText(TEXTSTRING *textstring, int16_t b, int16_t rate);
+void T_FlashText(TEXTSTRING *textstring, bool enable, int16_t rate);
 void T_AddBackground(
     TEXTSTRING *textstring, int16_t w, int16_t h, int16_t x, int16_t y);
 void T_RemoveBackground(TEXTSTRING *textstring);
-void T_AddOutline(TEXTSTRING *textstring, int16_t b);
+void T_AddOutline(TEXTSTRING *textstring, bool enable);
 void T_RemoveOutline(TEXTSTRING *textstring);
-void T_CentreH(TEXTSTRING *textstring, int16_t b);
-void T_CentreV(TEXTSTRING *textstring, int16_t b);
-void T_RightAlign(TEXTSTRING *textstring, int16_t b);
-void T_BottomAlign(TEXTSTRING *textstring, int16_t b);
+void T_CentreH(TEXTSTRING *textstring, bool enable);
+void T_CentreV(TEXTSTRING *textstring, bool enable);
+void T_RightAlign(TEXTSTRING *textstring, bool enable);
+void T_BottomAlign(TEXTSTRING *textstring, bool enable);
 int32_t T_GetTextWidth(TEXTSTRING *textstring);
 void T_RemovePrint(TEXTSTRING *textstring);
 void T_RemoveAllPrints();

--- a/src/game/text.h
+++ b/src/game/text.h
@@ -6,6 +6,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define TEXT_HEIGHT 11
+
 void Text_Init();
 TEXTSTRING *Text_Create(int16_t x, int16_t y, const char *string);
 void Text_ChangeText(TEXTSTRING *textstring, const char *string);

--- a/src/game/text.h
+++ b/src/game/text.h
@@ -24,6 +24,5 @@ int32_t Text_GetWidth(TEXTSTRING *textstring);
 void Text_Remove(TEXTSTRING *textstring);
 void Text_RemoveAll();
 void Text_Draw();
-void Text_DrawThisText(TEXTSTRING *textstring);
 
 #endif

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -162,10 +162,6 @@
 
 #define BIFF (WALL_L >> 1)
 
-#define MAX_STRING_SIZE 100
-#define MAX_TEXT_STRINGS 64
-
-#define TEXT_HEIGHT 11
 #define FRAME_BOUND_MIN_X 0
 #define FRAME_BOUND_MAX_X 1
 #define FRAME_BOUND_MIN_Y 2

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -760,19 +760,6 @@ typedef enum KEY_NUMBER {
     KEY_NUMBER_OF = 22,
 } KEY_NUMBER;
 
-typedef enum TEXTSTRING_FLAG {
-    TF_ACTIVE = 1 << 0,
-    TF_FLASH = 1 << 1,
-    TF_ROTATE_H = 1 << 2,
-    TF_ROTATE_V = 1 << 3,
-    TF_CENTRE_H = 1 << 4,
-    TF_CENTRE_V = 1 << 5,
-    TF_RIGHT = 1 << 7,
-    TF_BOTTOM = 1 << 8,
-    TF_BGND = 1 << 9,
-    TF_OUTLINE = 1 << 10,
-} TEXTSTRING_FLAG;
-
 typedef enum D_FLAGS {
     D_TRANS1 = 1,
     D_TRANS2 = 2,
@@ -1539,28 +1526,42 @@ typedef struct CREATURE_INFO {
 } CREATURE_INFO;
 
 typedef struct TEXTSTRING {
-    uint32_t flags;
-    uint16_t text_flags;
-    uint16_t bgnd_flags;
-    uint16_t outl_flags;
-    int16_t xpos;
-    int16_t ypos;
-    int16_t zpos; // unused
+    union {
+        uint32_t all;
+        struct {
+            uint32_t active : 1;
+            uint32_t flash : 1;
+            uint32_t rotate_h : 1;
+            uint32_t centre_h : 1;
+            uint32_t centre_v : 1;
+            uint32_t right : 1;
+            uint32_t bottom : 1;
+            uint32_t background : 1;
+            uint32_t outline : 1;
+        };
+    } flags;
+    struct {
+        int16_t x;
+        int16_t y;
+    } pos;
     int16_t letter_spacing;
     int16_t word_spacing;
-    int16_t flash_rate;
-    int16_t flash_count;
-    int16_t bgnd_colour; // unused
-    SG_COL *bgnd_gour; // unused
-    int16_t outl_colour; // unused
-    SG_COL *outl_gour; // unused
-    int16_t bgnd_size_x;
-    int16_t bgnd_size_y;
-    int16_t bgnd_off_x;
-    int16_t bgnd_off_y;
-    int16_t bgnd_off_z; // unused
-    int32_t scale_h;
-    int32_t scale_v;
+    struct {
+        int16_t rate;
+        int16_t count;
+    } flash;
+    struct {
+        int16_t x;
+        int16_t y;
+    } bgnd_size;
+    struct {
+        int16_t x;
+        int16_t y;
+    } bgnd_off;
+    struct {
+        int32_t h;
+        int32_t v;
+    } scale;
     char *string;
 } TEXTSTRING;
 

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1203,331 +1203,305 @@ typedef struct PcxHeader_t {
 } PCX_HEADER;
 
 typedef struct POS_2D {
-    /* 0000 */ uint16_t x;
-    /* 0002 */ uint16_t y;
-    /* 0004 end */
+    uint16_t x;
+    uint16_t y;
 } POS_2D;
 
 typedef struct POS_3D {
-    /* 0000 */ uint16_t x;
-    /* 0002 */ uint16_t y;
-    /* 0004 */ uint16_t z;
-    /* 0006 end */
+    uint16_t x;
+    uint16_t y;
+    uint16_t z;
 } POS_3D;
 
 typedef struct PHD_VECTOR {
-    /* 0000 */ int32_t x;
-    /* 0004 */ int32_t y;
-    /* 0008 */ int32_t z;
-    /* 000C end */
+    int32_t x;
+    int32_t y;
+    int32_t z;
 } PHD_VECTOR;
 
 typedef struct PHD_MATRIX {
-    /* 0000 */ int32_t _00;
-    /* 0004 */ int32_t _01;
-    /* 0008 */ int32_t _02;
-    /* 000C */ int32_t _03;
-    /* 0010 */ int32_t _10;
-    /* 0014 */ int32_t _11;
-    /* 0018 */ int32_t _12;
-    /* 001C */ int32_t _13;
-    /* 0020 */ int32_t _20;
-    /* 0024 */ int32_t _21;
-    /* 0028 */ int32_t _22;
-    /* 002C */ int32_t _23;
-    /* 0030 end */
+    int32_t _00;
+    int32_t _01;
+    int32_t _02;
+    int32_t _03;
+    int32_t _10;
+    int32_t _11;
+    int32_t _12;
+    int32_t _13;
+    int32_t _20;
+    int32_t _21;
+    int32_t _22;
+    int32_t _23;
 } PHD_MATRIX;
 
 typedef struct PHD_3DPOS {
-    /* 0000 */ int32_t x;
-    /* 0004 */ int32_t y;
-    /* 0008 */ int32_t z;
-    /* 000C */ int16_t x_rot;
-    /* 000E */ int16_t y_rot;
-    /* 0010 */ int16_t z_rot;
-    /* 0012 end */
+    int32_t x;
+    int32_t y;
+    int32_t z;
+    int16_t x_rot;
+    int16_t y_rot;
+    int16_t z_rot;
 } PHD_3DPOS;
 
 typedef struct POINT_INFO {
-    /* 0000 */ float xv;
-    /* 0004 */ float yv;
-    /* 0008 */ float zv;
-    /* 000C */ float xs;
-    /* 0010 */ float ys;
-    /* 0014 */ float u;
-    /* 0018 */ float v;
-    /* 001C */ float g;
-    /* 0020 end */
+    float xv;
+    float yv;
+    float zv;
+    float xs;
+    float ys;
+    float u;
+    float v;
+    float g;
 } POINT_INFO;
 
 typedef struct PHD_VBUF {
-    /* 0000 */ int32_t xv;
-    /* 0004 */ int32_t yv;
-    /* 0008 */ int32_t zv;
-    /* 000C */ int32_t xs;
-    /* 0010 */ int32_t ys;
-    /* 0014 */ int32_t dist;
-    /* 0018 */ int16_t clip;
-    /* 001A */ int16_t g;
-    /* 001C */ uint16_t u;
-    /* 001E */ uint16_t v;
-    /* 0020 end */
+    int32_t xv;
+    int32_t yv;
+    int32_t zv;
+    int32_t xs;
+    int32_t ys;
+    int32_t dist;
+    int16_t clip;
+    int16_t g;
+    uint16_t u;
+    uint16_t v;
 } PHD_VBUF;
 
 typedef struct PHD_UV {
-    /* 0000 */ uint16_t u1;
-    /* 0002 */ uint16_t v1;
-    /* 0004 end */
+    uint16_t u1;
+    uint16_t v1;
 } PHD_UV;
 
 typedef struct PHD_TEXTURE {
-    /* 0000 */ uint16_t drawtype;
-    /* 0002 */ uint16_t tpage;
-    /* 0004 */ PHD_UV uv[4];
-    /* 0014 end */
+    uint16_t drawtype;
+    uint16_t tpage;
+    PHD_UV uv[4];
 } PHD_TEXTURE;
 
 typedef struct PHD_SPRITE {
-    /* 0000 */ uint16_t tpage;
-    /* 0002 */ uint16_t offset;
-    /* 0004 */ uint16_t width;
-    /* 0006 */ uint16_t height;
-    /* 0008 */ int16_t x1;
-    /* 000A */ int16_t y1;
-    /* 000C */ int16_t x2;
-    /* 000E */ int16_t y2;
-    /* 0010 end */
+    uint16_t tpage;
+    uint16_t offset;
+    uint16_t width;
+    uint16_t height;
+    int16_t x1;
+    int16_t y1;
+    int16_t x2;
+    int16_t y2;
 } PHD_SPRITE;
 
 typedef struct DOOR_INFO {
-    /* 0000 */ int16_t room_num;
-    /* 0002 */ int16_t x;
-    /* 0004 */ int16_t y;
-    /* 0006 */ int16_t z;
-    /* 0008 */ POS_3D vertex[4];
-    /* 0020 end */
+    int16_t room_num;
+    int16_t x;
+    int16_t y;
+    int16_t z;
+    POS_3D vertex[4];
 } DOOR_INFO;
 
 typedef struct DOOR_INFOS {
-    /* 0000 */ uint16_t count;
-    /* 0002 */ DOOR_INFO door[];
-    /* 0006 end */
+    uint16_t count;
+    DOOR_INFO door[];
 } DOOR_INFOS;
 
 typedef struct FLOOR_INFO {
-    /* 0000 */ uint16_t index;
-    /* 0002 */ int16_t box;
-    /* 0004 */ uint8_t pit_room;
-    /* 0005 */ int8_t floor;
-    /* 0006 */ uint8_t sky_room;
-    /* 0007 */ int8_t ceiling;
-    /* 0008 end */
+    uint16_t index;
+    int16_t box;
+    uint8_t pit_room;
+    int8_t floor;
+    uint8_t sky_room;
+    int8_t ceiling;
 } FLOOR_INFO;
 
 typedef struct DOORPOS_DATA {
-    /* 0000 */ FLOOR_INFO *floor;
-    /* 0004 */ FLOOR_INFO old_floor;
-    /* 000C */ int16_t block;
-    /* 000E end */
+    FLOOR_INFO *floor;
+    FLOOR_INFO old_floor;
+    int16_t block;
 } DOORPOS_DATA;
 
 typedef struct DOOR_DATA {
-    /* 0000 */ DOORPOS_DATA d1;
-    /* 000E */ DOORPOS_DATA d1flip;
-    /* 001C */ DOORPOS_DATA d2;
-    /* 002A */ DOORPOS_DATA d2flip;
-    /* 0038 end */
+    DOORPOS_DATA d1;
+    DOORPOS_DATA d1flip;
+    DOORPOS_DATA d2;
+    DOORPOS_DATA d2flip;
 } DOOR_DATA;
 
 typedef struct LIGHT_INFO {
-    /* 0000 */ int32_t x;
-    /* 0004 */ int32_t y;
-    /* 0008 */ int32_t z;
-    /* 000C */ int16_t intensity;
-    /* 000E */ int32_t falloff;
-    /* 0012 end */
+    int32_t x;
+    int32_t y;
+    int32_t z;
+    int16_t intensity;
+    int32_t falloff;
 } LIGHT_INFO;
 
 typedef struct MESH_INFO {
-    /* 0000 */ uint32_t x;
-    /* 0004 */ uint32_t y;
-    /* 0008 */ uint32_t z;
-    /* 000C */ PHD_ANGLE y_rot;
-    /* 000E */ uint16_t shade;
-    /* 0010 */ uint16_t static_number;
-    /* 0012 end */
+    uint32_t x;
+    uint32_t y;
+    uint32_t z;
+    PHD_ANGLE y_rot;
+    uint16_t shade;
+    uint16_t static_number;
 } MESH_INFO;
 
 typedef struct ROOM_INFO {
-    /* 0000 */ int16_t *data;
-    /* 0004 */ DOOR_INFOS *doors;
-    /* 0008 */ FLOOR_INFO *floor;
-    /* 000C */ LIGHT_INFO *light;
-    /* 0010 */ MESH_INFO *mesh;
-    /* 0014 */ int32_t x;
-    /* 0018 */ int32_t y;
-    /* 001C */ int32_t z;
-    /* 0020 */ int32_t min_floor;
-    /* 0024 */ int32_t max_ceiling;
-    /* 0028 */ int16_t x_size;
-    /* 002A */ int16_t y_size;
-    /* 002C */ int16_t ambient;
-    /* 002E */ int16_t num_lights;
-    /* 0030 */ int16_t num_meshes;
-    /* 0032 */ int16_t left;
-    /* 0034 */ int16_t right;
-    /* 0036 */ int16_t top;
-    /* 0038 */ int16_t bottom;
-    /* 003A */ int16_t bound_active;
-    /* 003C */ int16_t item_number;
-    /* 003E */ int16_t fx_number;
-    /* 0040 */ int16_t flipped_room;
-    /* 0042 */ uint16_t flags;
-    /* 0044 end */
+    int16_t *data;
+    DOOR_INFOS *doors;
+    FLOOR_INFO *floor;
+    LIGHT_INFO *light;
+    MESH_INFO *mesh;
+    int32_t x;
+    int32_t y;
+    int32_t z;
+    int32_t min_floor;
+    int32_t max_ceiling;
+    int16_t x_size;
+    int16_t y_size;
+    int16_t ambient;
+    int16_t num_lights;
+    int16_t num_meshes;
+    int16_t left;
+    int16_t right;
+    int16_t top;
+    int16_t bottom;
+    int16_t bound_active;
+    int16_t item_number;
+    int16_t fx_number;
+    int16_t flipped_room;
+    uint16_t flags;
 } ROOM_INFO;
 
 typedef struct ITEM_INFO {
-    /* 0000 */ int32_t floor;
-    /* 0004 */ uint32_t touch_bits;
-    /* 0008 */ uint32_t mesh_bits;
-    /* 000C */ int16_t object_number;
-    /* 000E */ int16_t current_anim_state;
-    /* 0010 */ int16_t goal_anim_state;
-    /* 0012 */ int16_t required_anim_state;
-    /* 0014 */ int16_t anim_number;
-    /* 0016 */ int16_t frame_number;
-    /* 0018 */ int16_t room_number;
-    /* 001A */ int16_t next_item;
-    /* 001C */ int16_t next_active;
-    /* 001E */ int16_t speed;
-    /* 0020 */ int16_t fall_speed;
-    /* 0022 */ int16_t hit_points;
-    /* 0024 */ int16_t box_number;
-    /* 0026 */ int16_t timer;
-    /* 0028 */ int16_t flags;
-    /* 002A */ int16_t shade;
-    /* 002C */ void *data;
-    /* 0030 */ PHD_3DPOS pos;
-    /* 0042 */ uint16_t active : 1;
-    /*      */ uint16_t status : 2;
-    /*      */ uint16_t gravity_status : 1;
-    /*      */ uint16_t hit_status : 1;
-    /*      */ uint16_t collidable : 1;
-    /*      */ uint16_t looked_at : 1;
-    /* 0044 end */
+    int32_t floor;
+    uint32_t touch_bits;
+    uint32_t mesh_bits;
+    int16_t object_number;
+    int16_t current_anim_state;
+    int16_t goal_anim_state;
+    int16_t required_anim_state;
+    int16_t anim_number;
+    int16_t frame_number;
+    int16_t room_number;
+    int16_t next_item;
+    int16_t next_active;
+    int16_t speed;
+    int16_t fall_speed;
+    int16_t hit_points;
+    int16_t box_number;
+    int16_t timer;
+    int16_t flags;
+    int16_t shade;
+    void *data;
+    PHD_3DPOS pos;
+    uint16_t active : 1;
+    uint16_t status : 2;
+    uint16_t gravity_status : 1;
+    uint16_t hit_status : 1;
+    uint16_t collidable : 1;
+    uint16_t looked_at : 1;
 } ITEM_INFO;
 
 typedef struct LARA_ARM {
-    /* 0000 */ int16_t *frame_base;
-    /* 0004 */ int16_t frame_number;
-    /* 0006 */ int16_t lock;
-    /* 0008 */ PHD_ANGLE y_rot;
-    /* 000A */ PHD_ANGLE x_rot;
-    /* 000C */ PHD_ANGLE z_rot;
-    /* 000E */ uint16_t flash_gun;
-    /* 0010 end */
+    int16_t *frame_base;
+    int16_t frame_number;
+    int16_t lock;
+    PHD_ANGLE y_rot;
+    PHD_ANGLE x_rot;
+    PHD_ANGLE z_rot;
+    uint16_t flash_gun;
 } LARA_ARM;
 
 typedef struct AMMO_INFO {
-    /* 0000 */ int32_t ammo;
-    /* 0004 */ int32_t hit;
-    /* 0008 */ int32_t miss;
-    /* 000C end */
+    int32_t ammo;
+    int32_t hit;
+    int32_t miss;
 } AMMO_INFO;
 
 typedef struct BOX_NODE {
-    /* 0000 */ int16_t exit_box;
-    /* 0002 */ uint16_t search_number;
-    /* 0004 */ int16_t next_expansion;
-    /* 0006 */ int16_t box_number;
-    /* 0008 end */
+    int16_t exit_box;
+    uint16_t search_number;
+    int16_t next_expansion;
+    int16_t box_number;
 } BOX_NODE;
 
 typedef struct LOT_INFO {
-    /* 0000 */ BOX_NODE *node;
-    /* 0004 */ int16_t head;
-    /* 0006 */ int16_t tail;
-    /* 0008 */ uint16_t search_number;
-    /* 000A */ uint16_t block_mask;
-    /* 000C */ int16_t step;
-    /* 000E */ int16_t drop;
-    /* 0010 */ int16_t fly;
-    /* 0012 */ int16_t zone_count;
-    /* 0014 */ int16_t target_box;
-    /* 0016 */ int16_t required_box;
-    /* 0018 */ PHD_VECTOR target;
-    /* 0024 end */
+    BOX_NODE *node;
+    int16_t head;
+    int16_t tail;
+    uint16_t search_number;
+    uint16_t block_mask;
+    int16_t step;
+    int16_t drop;
+    int16_t fly;
+    int16_t zone_count;
+    int16_t target_box;
+    int16_t required_box;
+    PHD_VECTOR target;
 } LOT_INFO;
 
 typedef struct FX_INFO {
-    /* 0000 */ PHD_3DPOS pos;
-    /* 0012 */ int16_t room_number;
-    /* 0014 */ int16_t object_number;
-    /* 0016 */ int16_t next_fx;
-    /* 0018 */ int16_t next_active;
-    /* 001A */ int16_t speed;
-    /* 001C */ int16_t fall_speed;
-    /* 001E */ int16_t frame_number;
-    /* 0020 */ int16_t counter;
-    /* 0022 */ int16_t shade;
-    /* 0024 end */
+    PHD_3DPOS pos;
+    int16_t room_number;
+    int16_t object_number;
+    int16_t next_fx;
+    int16_t next_active;
+    int16_t speed;
+    int16_t fall_speed;
+    int16_t frame_number;
+    int16_t counter;
+    int16_t shade;
 } FX_INFO;
 
 typedef struct LARA_INFO {
-    /* 0000 */ int16_t item_number;
-    /* 0002 */ int16_t gun_status;
-    /* 0004 */ int16_t gun_type;
-    /* 0006 */ int16_t request_gun_type;
-    /* 0008 */ int16_t calc_fall_speed;
-    /* 000A */ int16_t water_status;
-    /* 000C */ int16_t pose_count;
-    /* 000E */ int16_t hit_frame;
-    /* 0010 */ int16_t hit_direction;
-    /* 0012 */ int16_t air;
-    /* 0014 */ int16_t dive_count;
-    /* 0016 */ int16_t death_count;
-    /* 0018 */ int16_t current_active;
-    /* 001A */ int16_t spaz_effect_count;
-    /* 001C */ FX_INFO *spaz_effect;
-    /* 0020 */ int32_t mesh_effects;
-    /* 0024 */ int16_t *mesh_ptrs[LM_NUMBER_OF];
-    /* 0060 */ ITEM_INFO *target;
-    /* 0064 */ PHD_ANGLE target_angles[2];
-    /* 0068 */ int16_t turn_rate;
-    /* 006A */ int16_t move_angle;
-    /* 006C */ int16_t head_y_rot;
-    /* 006E */ int16_t head_x_rot;
-    /* 0070 */ int16_t head_z_rot;
-    /* 0072 */ int16_t torso_y_rot;
-    /* 0074 */ int16_t torso_x_rot;
-    /* 0076 */ int16_t torso_z_rot;
-    /* 0078 */ LARA_ARM left_arm;
-    /* 0088 */ LARA_ARM right_arm;
-    /* 0098 */ AMMO_INFO pistols;
-    /* 00A4 */ AMMO_INFO magnums;
-    /* 00B0 */ AMMO_INFO uzis;
-    /* 00BC */ AMMO_INFO shotgun;
-    /* 00C8 */ LOT_INFO LOT;
-    /* 00E6 end */
+    int16_t item_number;
+    int16_t gun_status;
+    int16_t gun_type;
+    int16_t request_gun_type;
+    int16_t calc_fall_speed;
+    int16_t water_status;
+    int16_t pose_count;
+    int16_t hit_frame;
+    int16_t hit_direction;
+    int16_t air;
+    int16_t dive_count;
+    int16_t death_count;
+    int16_t current_active;
+    int16_t spaz_effect_count;
+    FX_INFO *spaz_effect;
+    int32_t mesh_effects;
+    int16_t *mesh_ptrs[LM_NUMBER_OF];
+    ITEM_INFO *target;
+    PHD_ANGLE target_angles[2];
+    int16_t turn_rate;
+    int16_t move_angle;
+    int16_t head_y_rot;
+    int16_t head_x_rot;
+    int16_t head_z_rot;
+    int16_t torso_y_rot;
+    int16_t torso_x_rot;
+    int16_t torso_z_rot;
+    LARA_ARM left_arm;
+    LARA_ARM right_arm;
+    AMMO_INFO pistols;
+    AMMO_INFO magnums;
+    AMMO_INFO uzis;
+    AMMO_INFO shotgun;
+    LOT_INFO LOT;
 } LARA_INFO;
 
 typedef struct START_INFO {
-    /* 0000 */ uint16_t pistol_ammo;
-    /* 0002 */ uint16_t magnum_ammo;
-    /* 0004 */ uint16_t uzi_ammo;
-    /* 0006 */ uint16_t shotgun_ammo;
-    /* 0008 */ uint8_t num_medis;
-    /* 0009 */ uint8_t num_big_medis;
-    /* 000A */ uint8_t num_scions;
-    /* 000B */ int8_t gun_status;
-    /* 000C */ int8_t gun_type;
-    /* 000D */ uint16_t available : 1;
-    /*      */ uint16_t got_pistols : 1;
-    /*      */ uint16_t got_magnums : 1;
-    /*      */ uint16_t got_uzis : 1;
-    /*      */ uint16_t got_shotgun : 1;
-    /*      */ uint16_t costume : 1;
-    /* 000F end */
+    uint16_t pistol_ammo;
+    uint16_t magnum_ammo;
+    uint16_t uzi_ammo;
+    uint16_t shotgun_ammo;
+    uint8_t num_medis;
+    uint8_t num_big_medis;
+    uint8_t num_scions;
+    int8_t gun_status;
+    int8_t gun_type;
+    uint16_t available : 1;
+    uint16_t got_pistols : 1;
+    uint16_t got_magnums : 1;
+    uint16_t got_uzis : 1;
+    uint16_t got_shotgun : 1;
+    uint16_t costume : 1;
 } START_INFO;
 
 typedef struct SAVEGAME_INFO {
@@ -1554,387 +1528,362 @@ typedef struct SAVEGAME_INFO {
 } SAVEGAME_INFO;
 
 typedef struct CREATURE_INFO {
-    /* 0000 */ int16_t head_rotation;
-    /* 0002 */ int16_t neck_rotation;
-    /* 0004 */ int16_t maximum_turn;
-    /* 0006 */ uint16_t flags;
-    /* 0008 */ int16_t item_num;
-    /* 000A */ int32_t mood;
-    /* 000E */ LOT_INFO LOT;
-    /* 002C */ PHD_VECTOR target;
-    /* 003E end */
+    int16_t head_rotation;
+    int16_t neck_rotation;
+    int16_t maximum_turn;
+    uint16_t flags;
+    int16_t item_num;
+    int32_t mood;
+    LOT_INFO LOT;
+    PHD_VECTOR target;
 } CREATURE_INFO;
 
 typedef struct TEXTSTRING {
-    /* 0000 */ uint32_t flags;
-    /* 0004 */ uint16_t text_flags;
-    /* 0006 */ uint16_t bgnd_flags;
-    /* 0008 */ uint16_t outl_flags;
-    /* 000A */ int16_t xpos;
-    /* 000C */ int16_t ypos;
-    /* 000E */ int16_t zpos; // unused
-    /* 0010 */ int16_t letter_spacing;
-    /* 0012 */ int16_t word_spacing;
-    /* 0014 */ int16_t flash_rate;
-    /* 0016 */ int16_t flash_count;
-    /* 0018 */ int16_t bgnd_colour; // unused
-    /* 001A */ SG_COL *bgnd_gour; // unused
-    /* 001E */ int16_t outl_colour; // unused
-    /* 0020 */ SG_COL *outl_gour; // unused
-    /* 0024 */ int16_t bgnd_size_x;
-    /* 0026 */ int16_t bgnd_size_y;
-    /* 0028 */ int16_t bgnd_off_x;
-    /* 002A */ int16_t bgnd_off_y;
-    /* 002C */ int16_t bgnd_off_z; // unused
-    /* 002E */ int32_t scale_h;
-    /* 0032 */ int32_t scale_v;
-    /* 0034 */ char *string;
-    /* 0038 end */
+    uint32_t flags;
+    uint16_t text_flags;
+    uint16_t bgnd_flags;
+    uint16_t outl_flags;
+    int16_t xpos;
+    int16_t ypos;
+    int16_t zpos; // unused
+    int16_t letter_spacing;
+    int16_t word_spacing;
+    int16_t flash_rate;
+    int16_t flash_count;
+    int16_t bgnd_colour; // unused
+    SG_COL *bgnd_gour; // unused
+    int16_t outl_colour; // unused
+    SG_COL *outl_gour; // unused
+    int16_t bgnd_size_x;
+    int16_t bgnd_size_y;
+    int16_t bgnd_off_x;
+    int16_t bgnd_off_y;
+    int16_t bgnd_off_z; // unused
+    int32_t scale_h;
+    int32_t scale_v;
+    char *string;
 } TEXTSTRING;
 
 typedef struct DISPLAYPU {
-    /* 0000 */ int16_t duration;
-    /* 0002 */ int16_t sprnum;
-    /* 0004 end */
+    int16_t duration;
+    int16_t sprnum;
 } DISPLAYPU;
 
 typedef struct COLL_INFO {
-    /* 0000 */ int32_t mid_floor;
-    /* 0004 */ int32_t mid_ceiling;
-    /* 0008 */ int32_t mid_type;
-    /* 000C */ int32_t front_floor;
-    /* 0010 */ int32_t front_ceiling;
-    /* 0014 */ int32_t front_type;
-    /* 0018 */ int32_t left_floor;
-    /* 001C */ int32_t left_ceiling;
-    /* 0020 */ int32_t left_type;
-    /* 0024 */ int32_t right_floor;
-    /* 0028 */ int32_t right_ceiling;
-    /* 002C */ int32_t right_type;
-    /* 0030 */ int32_t radius;
-    /* 0034 */ int32_t bad_pos;
-    /* 0038 */ int32_t bad_neg;
-    /* 003C */ int32_t bad_ceiling;
-    /* 0040 */ PHD_VECTOR shift;
-    /* 0046 */ PHD_VECTOR old;
-    /* 004C */ int16_t facing;
-    /* 004E */ int16_t quadrant;
-    /* 0050 */ int16_t coll_type;
-    /* 0052 */ int16_t *trigger;
-    /* 0056 */ int8_t tilt_x;
-    /* 0057 */ int8_t tilt_z;
-    /* 0058 */ int8_t hit_by_baddie;
-    /* 0059 */ int8_t hit_static;
-    /* 005A */ uint16_t slopes_are_walls : 1;
-    /*      */ uint16_t slopes_are_pits : 1;
-    /*      */ uint16_t lava_is_pit : 1;
-    /*      */ uint16_t enable_baddie_push : 1;
-    /*      */ uint16_t enable_spaz : 1;
-    /* 005C end */
+    int32_t mid_floor;
+    int32_t mid_ceiling;
+    int32_t mid_type;
+    int32_t front_floor;
+    int32_t front_ceiling;
+    int32_t front_type;
+    int32_t left_floor;
+    int32_t left_ceiling;
+    int32_t left_type;
+    int32_t right_floor;
+    int32_t right_ceiling;
+    int32_t right_type;
+    int32_t radius;
+    int32_t bad_pos;
+    int32_t bad_neg;
+    int32_t bad_ceiling;
+    PHD_VECTOR shift;
+    PHD_VECTOR old;
+    int16_t facing;
+    int16_t quadrant;
+    int16_t coll_type;
+    int16_t *trigger;
+    int8_t tilt_x;
+    int8_t tilt_z;
+    int8_t hit_by_baddie;
+    int8_t hit_static;
+    uint16_t slopes_are_walls : 1;
+    uint16_t slopes_are_pits : 1;
+    uint16_t lava_is_pit : 1;
+    uint16_t enable_baddie_push : 1;
+    uint16_t enable_spaz : 1;
 } COLL_INFO;
 
 typedef struct OBJECT_INFO {
-    /* 0000 */ int16_t nmeshes;
-    /* 0002 */ int16_t mesh_index;
-    /* 0004 */ int32_t bone_index;
-    /* 0008 */ int16_t *frame_base;
-    /* 000C */ void (*initialise)(int16_t item_num);
-    /* 0010 */ void (*control)(int16_t item_num);
-    /* 0014 */ void (*floor)(
+    int16_t nmeshes;
+    int16_t mesh_index;
+    int32_t bone_index;
+    int16_t *frame_base;
+    void (*initialise)(int16_t item_num);
+    void (*control)(int16_t item_num);
+    void (*floor)(
         ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-    /* 0018 */ void (*ceiling)(
+    void (*ceiling)(
         ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-    /* 001C */ void (*draw_routine)(ITEM_INFO *item);
-    /* 0020 */ void (*collision)(
-        int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll);
-    /* 0024 */ int16_t anim_index;
-    /* 0026 */ int16_t hit_points;
-    /* 0028 */ int16_t pivot_length;
-    /* 002A */ int16_t radius;
-    /* 002C */ int16_t smartness;
-    /* 002E */ int16_t shadow_size;
-    /* 0030 */ uint16_t loaded : 1;
-    /*      */ uint16_t intelligent : 1;
-    /*      */ uint16_t save_position : 1;
-    /*      */ uint16_t save_hitpoints : 1;
-    /*      */ uint16_t save_flags : 1;
-    /*      */ uint16_t save_anim : 1;
-    /* 0032 end */
+    void (*draw_routine)(ITEM_INFO *item);
+    void (*collision)(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll);
+    int16_t anim_index;
+    int16_t hit_points;
+    int16_t pivot_length;
+    int16_t radius;
+    int16_t smartness;
+    int16_t shadow_size;
+    uint16_t loaded : 1;
+    uint16_t intelligent : 1;
+    uint16_t save_position : 1;
+    uint16_t save_hitpoints : 1;
+    uint16_t save_flags : 1;
+    uint16_t save_anim : 1;
 } OBJECT_INFO;
 
 typedef struct SHADOW_INFO {
-    /* 0000 */ int16_t x;
-    /* 0002 */ int16_t y;
-    /* 0004 */ int16_t z;
-    /* 0006 */ int16_t radius;
-    /* 0008 */ int16_t poly_count;
-    /* 000A */ int16_t vertex_count;
-    /* 000C */ POS_3D vertex[32];
-    /* 003C end */
+    int16_t x;
+    int16_t y;
+    int16_t z;
+    int16_t radius;
+    int16_t poly_count;
+    int16_t vertex_count;
+    POS_3D vertex[32];
 } SHADOW_INFO;
 
 typedef struct STATIC_INFO {
-    /* 0000 */ int16_t mesh_number;
-    /* 0002 */ int16_t flags;
-    /* 0004 */ int16_t x_minp;
-    /* 0006 */ int16_t x_maxp;
-    /* 0008 */ int16_t y_minp;
-    /* 000A */ int16_t y_maxp;
-    /* 000C */ int16_t z_minp;
-    /* 000E */ int16_t z_maxp;
-    /* 0010 */ int16_t x_minc;
-    /* 0012 */ int16_t x_maxc;
-    /* 0014 */ int16_t y_minc;
-    /* 0016 */ int16_t y_maxc;
-    /* 0018 */ int16_t z_minc;
-    /* 001A */ int16_t z_maxc;
-    /* 001C end */
+    int16_t mesh_number;
+    int16_t flags;
+    int16_t x_minp;
+    int16_t x_maxp;
+    int16_t y_minp;
+    int16_t y_maxp;
+    int16_t z_minp;
+    int16_t z_maxp;
+    int16_t x_minc;
+    int16_t x_maxc;
+    int16_t y_minc;
+    int16_t y_maxc;
+    int16_t z_minc;
+    int16_t z_maxc;
 } STATIC_INFO;
 
 typedef struct GAME_VECTOR {
-    /* 0000 */ int32_t x;
-    /* 0004 */ int32_t y;
-    /* 0008 */ int32_t z;
-    /* 000C */ int16_t room_number;
-    /* 000E */ int16_t box_number;
-    /* 0010 end */
+    int32_t x;
+    int32_t y;
+    int32_t z;
+    int16_t room_number;
+    int16_t box_number;
 } GAME_VECTOR;
 
 typedef struct OBJECT_VECTOR {
-    /* 0000 */ int32_t x;
-    /* 0004 */ int32_t y;
-    /* 0008 */ int32_t z;
-    /* 000C */ int16_t data;
-    /* 000E */ int16_t flags;
-    /* 0010 end */
+    int32_t x;
+    int32_t y;
+    int32_t z;
+    int16_t data;
+    int16_t flags;
 } OBJECT_VECTOR;
 
 typedef struct CAMERA_INFO {
-    /* 0000 */ GAME_VECTOR pos;
-    /* 0010 */ GAME_VECTOR target;
-    /* 0020 */ int32_t type;
-    /* 0024 */ int32_t shift;
-    /* 0028 */ int32_t flags;
-    /* 002C */ int32_t fixed_camera;
-    /* 0030 */ int32_t number_frames;
-    /* 0034 */ int32_t bounce;
-    /* 0038 */ int32_t underwater;
-    /* 003C */ int32_t target_distance;
-    /* 0040 */ int32_t target_square;
-    /* 0044 */ int16_t target_angle;
-    /* 0046 */ int16_t actual_angle;
-    /* 0048 */ int16_t target_elevation;
-    /* 004A */ int16_t box;
-    /* 004C */ int16_t number;
-    /* 004E */ int16_t last;
-    /* 0050 */ int16_t timer;
-    /* 0052 */ int16_t speed;
-    /* 0054 */ ITEM_INFO *item;
-    /* 0058 */ ITEM_INFO *last_item;
-    /* 005C */ OBJECT_VECTOR *fixed;
-    /* 0060 end */
+    GAME_VECTOR pos;
+    GAME_VECTOR target;
+    int32_t type;
+    int32_t shift;
+    int32_t flags;
+    int32_t fixed_camera;
+    int32_t number_frames;
+    int32_t bounce;
+    int32_t underwater;
+    int32_t target_distance;
+    int32_t target_square;
+    int16_t target_angle;
+    int16_t actual_angle;
+    int16_t target_elevation;
+    int16_t box;
+    int16_t number;
+    int16_t last;
+    int16_t timer;
+    int16_t speed;
+    ITEM_INFO *item;
+    ITEM_INFO *last_item;
+    OBJECT_VECTOR *fixed;
     // used for the manual camera control
     int16_t additional_angle;
     int16_t additional_elevation;
 } CAMERA_INFO;
 
 typedef struct ANIM_STRUCT {
-    /* 0000 */ int16_t *frame_ptr;
-    /* 0004 */ int16_t interpolation;
-    /* 0006 */ int16_t current_anim_state;
-    /* 0008 */ int32_t velocity;
-    /* 000C */ int32_t acceleration;
-    /* 0010 */ int16_t frame_base;
-    /* 0012 */ int16_t frame_end;
-    /* 0014 */ int16_t jump_anim_num;
-    /* 0016 */ int16_t jump_frame_num;
-    /* 0018 */ int16_t number_changes;
-    /* 001A */ int16_t change_index;
-    /* 001C */ int16_t number_commands;
-    /* 001E */ int16_t command_index;
-    /* 0020 end */
+    int16_t *frame_ptr;
+    int16_t interpolation;
+    int16_t current_anim_state;
+    int32_t velocity;
+    int32_t acceleration;
+    int16_t frame_base;
+    int16_t frame_end;
+    int16_t jump_anim_num;
+    int16_t jump_frame_num;
+    int16_t number_changes;
+    int16_t change_index;
+    int16_t number_commands;
+    int16_t command_index;
 } ANIM_STRUCT;
 
 typedef struct ANIM_CHANGE_STRUCT {
-    /* 0000 */ int16_t goal_anim_state;
-    /* 0004 */ int16_t number_ranges;
-    /* 0006 */ int16_t range_index;
-    /* 0008 end */
+    int16_t goal_anim_state;
+    int16_t number_ranges;
+    int16_t range_index;
 } ANIM_CHANGE_STRUCT;
 
 typedef struct ANIM_RANGE_STRUCT {
-    /* 0000 */ int16_t start_frame;
-    /* 0004 */ int16_t end_frame;
-    /* 0006 */ int16_t link_anim_num;
-    /* 0008 */ int16_t link_frame_num;
-    /* 000A end */
+    int16_t start_frame;
+    int16_t end_frame;
+    int16_t link_anim_num;
+    int16_t link_frame_num;
 } ANIM_RANGE_STRUCT;
 
 typedef struct DOOR_VBUF {
-    /* 0000 */ int32_t xv;
-    /* 0004 */ int32_t yv;
-    /* 0008 */ int32_t zv;
-    /* 000C end */
+    int32_t xv;
+    int32_t yv;
+    int32_t zv;
 } DOOR_VBUF;
 
 typedef struct WEAPON_INFO {
-    /* 0000 */ PHD_ANGLE lock_angles[4];
-    /* 0008 */ PHD_ANGLE left_angles[4];
-    /* 0010 */ PHD_ANGLE right_angles[4];
-    /* 0018 */ PHD_ANGLE aim_speed;
-    /* 001A */ PHD_ANGLE shot_accuracy;
-    /* 001C */ int32_t gun_height;
-    /* 0020 */ int32_t damage;
-    /* 0024 */ int32_t target_dist;
-    /* 0028 */ int16_t recoil_frame;
-    /* 002A */ int16_t flash_time;
-    /* 002C */ int16_t sample_num;
-    /* 002E end */
+    PHD_ANGLE lock_angles[4];
+    PHD_ANGLE left_angles[4];
+    PHD_ANGLE right_angles[4];
+    PHD_ANGLE aim_speed;
+    PHD_ANGLE shot_accuracy;
+    int32_t gun_height;
+    int32_t damage;
+    int32_t target_dist;
+    int16_t recoil_frame;
+    int16_t flash_time;
+    int16_t sample_num;
 } WEAPON_INFO;
 
 typedef struct SPHERE {
-    /* 0000 */ int32_t x;
-    /* 0004 */ int32_t y;
-    /* 0008 */ int32_t z;
-    /* 000C */ int32_t r;
-    /* 0010 end */
+    int32_t x;
+    int32_t y;
+    int32_t z;
+    int32_t r;
 } SPHERE;
 
 typedef struct BITE_INFO {
-    /* 0000 */ int32_t x;
-    /* 0004 */ int32_t y;
-    /* 0008 */ int32_t z;
-    /* 000C */ int32_t mesh_num;
-    /* 0010 end */
+    int32_t x;
+    int32_t y;
+    int32_t z;
+    int32_t mesh_num;
 } BITE_INFO;
 
 typedef struct AI_INFO {
-    /* 0000 */ int16_t zone_number;
-    /* 0002 */ int16_t enemy_zone;
-    /* 0004 */ int32_t distance;
-    /* 0008 */ int32_t ahead;
-    /* 000C */ int32_t bite;
-    /* 000E */ int16_t angle;
-    /* 0010 */ int16_t enemy_facing;
-    /* 0012 end */
+    int16_t zone_number;
+    int16_t enemy_zone;
+    int32_t distance;
+    int32_t ahead;
+    int32_t bite;
+    int16_t angle;
+    int16_t enemy_facing;
 } AI_INFO;
 
 typedef struct BOX_INFO {
-    /* 0000 */ int32_t left;
-    /* 0004 */ int32_t right;
-    /* 0008 */ int32_t top;
-    /* 000C */ int32_t bottom;
-    /* 0010 */ int16_t height;
-    /* 0012 */ int16_t overlap_index;
-    /* 0014 end */
+    int32_t left;
+    int32_t right;
+    int32_t top;
+    int32_t bottom;
+    int16_t height;
+    int16_t overlap_index;
 } BOX_INFO;
 
 typedef struct REQUEST_INFO {
-    /* 0000 */ uint16_t items;
-    /* 0002 */ uint16_t requested;
-    /* 0004 */ uint16_t vis_lines;
-    /* 0006 */ uint16_t line_offset;
-    /* 0008 */ uint16_t line_old_offset;
-    /* 000A */ uint16_t pix_width;
-    /* 000C */ uint16_t line_height;
-    /* 000E */ int16_t x;
-    /* 0010 */ int16_t y;
-    /* 0012 */ int16_t z; // unused
-    /* 0014 */ uint16_t flags;
-    /* 0016 */ const char *heading_text;
-    /* 0020 */ char *item_texts;
-    /* 001E */ int16_t item_text_len;
-    /* 0020 */ TEXTSTRING *heading;
-    /* 0024 */ TEXTSTRING *background;
-    /* 0028 */ TEXTSTRING *moreup;
-    /* 002C */ TEXTSTRING *moredown;
-    /* 0030 */ TEXTSTRING *texts[MAX_REQLINES];
-    /* 0070 */ uint16_t item_flags[MAX_REQLINES];
-    /* 0090 end */
+    uint16_t items;
+    uint16_t requested;
+    uint16_t vis_lines;
+    uint16_t line_offset;
+    uint16_t line_old_offset;
+    uint16_t pix_width;
+    uint16_t line_height;
+    int16_t x;
+    int16_t y;
+    int16_t z; // unused
+    uint16_t flags;
+    const char *heading_text;
+    char *item_texts;
+    int16_t item_text_len;
+    TEXTSTRING *heading;
+    TEXTSTRING *background;
+    TEXTSTRING *moreup;
+    TEXTSTRING *moredown;
+    TEXTSTRING *texts[MAX_REQLINES];
+    uint16_t item_flags[MAX_REQLINES];
 } REQUEST_INFO;
 
 typedef struct IMOTION_INFO {
-    /* 0000 */ int16_t count;
-    /* 0002 */ int16_t status;
-    /* 0004 */ int16_t status_target;
-    /* 0006 */ int16_t radius_target;
-    /* 0008 */ int16_t radius_rate;
-    /* 000A */ int16_t camera_ytarget;
-    /* 000C */ int16_t camera_yrate;
-    /* 000E */ int16_t camera_pitch_target;
-    /* 0010 */ int16_t camera_pitch_rate;
-    /* 0012 */ int16_t rotate_target;
-    /* 0014 */ int16_t rotate_rate;
-    /* 0016 */ PHD_ANGLE item_ptxrot_target;
-    /* 0018 */ PHD_ANGLE item_ptxrot_rate;
-    /* 001A */ PHD_ANGLE item_xrot_target;
-    /* 001C */ PHD_ANGLE item_xrot_rate;
-    /* 001E */ int32_t item_ytrans_target;
-    /* 0022 */ int32_t item_ytrans_rate;
-    /* 0026 */ int32_t item_ztrans_target;
-    /* 002A */ int32_t item_ztrans_rate;
-    /* 002E */ int32_t misc;
-    /* 0032 end */
+    int16_t count;
+    int16_t status;
+    int16_t status_target;
+    int16_t radius_target;
+    int16_t radius_rate;
+    int16_t camera_ytarget;
+    int16_t camera_yrate;
+    int16_t camera_pitch_target;
+    int16_t camera_pitch_rate;
+    int16_t rotate_target;
+    int16_t rotate_rate;
+    PHD_ANGLE item_ptxrot_target;
+    PHD_ANGLE item_ptxrot_rate;
+    PHD_ANGLE item_xrot_target;
+    PHD_ANGLE item_xrot_rate;
+    int32_t item_ytrans_target;
+    int32_t item_ytrans_rate;
+    int32_t item_ztrans_target;
+    int32_t item_ztrans_rate;
+    int32_t misc;
 } IMOTION_INFO;
 
 typedef struct INVENTORY_SPRITE {
-    /* 0000 */ int16_t shape;
-    /* 0002 */ int16_t x;
-    /* 0004 */ int16_t y;
-    /* 0006 */ int16_t z;
-    /* 0008 */ int32_t param1;
-    /* 000C */ int32_t param2;
-    /* 0010 */ SG_COL *grdptr;
-    /* 0014 */ int16_t sprnum;
-    /* 0016 end */
+    int16_t shape;
+    int16_t x;
+    int16_t y;
+    int16_t z;
+    int32_t param1;
+    int32_t param2;
+    SG_COL *grdptr;
+    int16_t sprnum;
 } INVENTORY_SPRITE;
 
 typedef struct INVENTORY_ITEM {
-    /* 0000 */ char *string;
-    /* 0004 */ int16_t object_number;
-    /* 0006 */ int16_t frames_total;
-    /* 0008 */ int16_t current_frame;
-    /* 000A */ int16_t goal_frame;
-    /* 000C */ int16_t open_frame;
-    /* 000E */ int16_t anim_direction;
-    /* 0010 */ int16_t anim_speed;
-    /* 0012 */ int16_t anim_count;
-    /* 0014 */ PHD_ANGLE pt_xrot_sel;
-    /* 0016 */ PHD_ANGLE pt_xrot;
-    /* 0018 */ PHD_ANGLE x_rot_sel;
-    /* 001A */ PHD_ANGLE x_rot;
-    /* 001C */ PHD_ANGLE y_rot_sel;
-    /* 001E */ PHD_ANGLE y_rot;
-    /* 0020 */ int32_t ytrans_sel;
-    /* 0024 */ int32_t ytrans;
-    /* 0028 */ int32_t ztrans_sel;
-    /* 002C */ int32_t ztrans;
-    /* 0030 */ uint32_t which_meshes;
-    /* 0034 */ uint32_t drawn_meshes;
-    /* 0038 */ int16_t inv_pos;
-    /* 003A */ INVENTORY_SPRITE **sprlist;
-    /* 003E end */
+    char *string;
+    int16_t object_number;
+    int16_t frames_total;
+    int16_t current_frame;
+    int16_t goal_frame;
+    int16_t open_frame;
+    int16_t anim_direction;
+    int16_t anim_speed;
+    int16_t anim_count;
+    PHD_ANGLE pt_xrot_sel;
+    PHD_ANGLE pt_xrot;
+    PHD_ANGLE x_rot_sel;
+    PHD_ANGLE x_rot;
+    PHD_ANGLE y_rot_sel;
+    PHD_ANGLE y_rot;
+    int32_t ytrans_sel;
+    int32_t ytrans;
+    int32_t ztrans_sel;
+    int32_t ztrans;
+    uint32_t which_meshes;
+    uint32_t drawn_meshes;
+    int16_t inv_pos;
+    INVENTORY_SPRITE **sprlist;
 } INVENTORY_ITEM;
 
 typedef struct RING_INFO {
-    /* 0000 */ INVENTORY_ITEM **list;
-    /* 0004 */ int16_t type;
-    /* 0006 */ int16_t radius;
-    /* 0008 */ int16_t camera_pitch;
-    /* 000A */ int16_t rotating;
-    /* 000C */ int16_t rot_count;
-    /* 000E */ int16_t current_object;
-    /* 0010 */ int16_t target_object;
-    /* 0012 */ int16_t number_of_objects;
-    /* 0014 */ int16_t angle_adder;
-    /* 0016 */ int16_t rot_adder;
-    /* 0018 */ int16_t rot_adder_l;
-    /* 001A */ int16_t rot_adder_r;
-    /* 001C */ PHD_3DPOS ringpos;
-    /* 002E */ PHD_3DPOS camera;
-    /* 0040 */ PHD_VECTOR light;
-    /* 004C */ IMOTION_INFO *imo;
-    /* 0050 end */
+    INVENTORY_ITEM **list;
+    int16_t type;
+    int16_t radius;
+    int16_t camera_pitch;
+    int16_t rotating;
+    int16_t rot_count;
+    int16_t current_object;
+    int16_t target_object;
+    int16_t number_of_objects;
+    int16_t angle_adder;
+    int16_t rot_adder;
+    int16_t rot_adder_l;
+    int16_t rot_adder_r;
+    PHD_3DPOS ringpos;
+    PHD_3DPOS camera;
+    PHD_VECTOR light;
+    IMOTION_INFO *imo;
 } RING_INFO;
 
 typedef struct GAMEFLOW_SEQUENCE {

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1563,6 +1563,8 @@ typedef struct TEXTSTRING {
         int32_t v;
     } scale;
     char *string;
+
+    void (*on_remove)(const struct TEXTSTRING *);
 } TEXTSTRING;
 
 typedef struct DISPLAYPU {

--- a/src/global/vars.c
+++ b/src/global/vars.c
@@ -16,9 +16,6 @@
 #include "global/vars.h"
 
 char *GameMemoryPointer = NULL;
-TEXTSTRING *VersionText = NULL;
-TEXTSTRING *AmmoText = NULL;
-TEXTSTRING *FPSText = NULL;
 int32_t FPSCounter = 0;
 
 void (*EffectRoutines[])(ITEM_INFO *item) = {

--- a/src/global/vars.h
+++ b/src/global/vars.h
@@ -56,9 +56,6 @@ extern bool MusicLoop;
 extern uint16_t MusicTrackFlags[MAX_CD_TRACKS];
 extern int32_t MnSoundMasterVolume;
 
-extern TEXTSTRING *VersionText;
-extern TEXTSTRING *AmmoText;
-extern TEXTSTRING *FPSText;
 extern int32_t FPSCounter;
 
 extern void (*EffectRoutines[])(ITEM_INFO *item);

--- a/src/specific/init.c
+++ b/src/specific/init.c
@@ -3,6 +3,7 @@
 #include "global/lib.h"
 #include "3dsystem/phd_math.h"
 #include "game/game.h"
+#include "game/text.h"
 #include "global/vars.h"
 #include "specific/clock.h"
 #include "specific/file.h"
@@ -69,7 +70,7 @@ void S_InitialiseSystem()
     S_SeedRandom();
 
     Lib_Init();
-
+    Text_Init();
     ClockInit();
     SoundIsActive = SoundInit();
     MusicInit();

--- a/src/specific/shell.c
+++ b/src/specific/shell.c
@@ -107,7 +107,7 @@ void GameMain()
             break;
 
         case GF_EXIT_TO_TITLE:
-            T_InitPrint();
+            Text_Init();
             TempVideoAdjust(2);
             S_DisplayPicture("data\\titleh");
             NoInputCount = 0;

--- a/src/specific/shell.c
+++ b/src/specific/shell.c
@@ -107,7 +107,7 @@ void GameMain()
             break;
 
         case GF_EXIT_TO_TITLE:
-            Text_Init();
+            Text_RemoveAll();
             TempVideoAdjust(2);
             S_DisplayPicture("data\\titleh");
             NoInputCount = 0;


### PR DESCRIPTION
Similar refactors to what we have in #186 . One curiosity is the introduction of `on_remove` hook in `TEXSTRING*` to achieve inversion of control with regards to global pointer invalidation for static textstrings (details in the commit message).