### PR TITLE
build: support local branches versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ WINDRES=i686-w64-mingw32-windres
 LDFLAGS=-ldbghelp -lwinmm -ldsound -lddraw -ldinput8 -ldxguid
 CFLAGS=-Wall -Isrc -DVERSION='"T1M ${VERSION}"'
 
-VERSION = $(shell git describe --abbrev=7 --tags master)
+VERSION = $(shell git describe --abbrev=7 --tags)
 CWD = $(shell pwd)
 C_FILES = $(shell find src/ -type f -name '*.c')
 H_FILES = $(shell find src/ -type f -name '*.h')


### PR DESCRIPTION
This improves the version output when compiling
on a branch that is not master.

Let's say we're on a branch called `audio_refactor`,
12 commits ahead of `master`.

Before the version would say:

    T1M 1.3.0

After this commit, the version would say:

    T1M 1.3.0-12-gf65378c