### PR TITLE
ENUM type mismatch

### DIFF
--- a/src/specific/input.c
+++ b/src/specific/input.c
@@ -335,7 +335,7 @@ EnumAxesCallback(LPCDIDEVICEOBJECTINSTANCE instance, LPVOID context)
     return DIENUM_CONTINUE;
 }
 
-static BOOL CALLBACK EnumCallback(LPCDIDEVICEINSTANCEA instance, LPVOID context)
+static BOOL CALLBACK EnumCallback(LPCDIDEVICEINSTANCE instance, LPVOID context)
 {
     HRESULT result;
 


### PR DESCRIPTION
probably doesn't happen for you because Linux lives in the A world, while my Windows is W so they mismatch for me.