### PR TITLE
clear GameMemory

### DIFF
--- a/src/specific/init.c
+++ b/src/specific/init.c
@@ -104,6 +104,7 @@ void init_game_malloc()
     if (!GameMemoryPointer) {
         S_ExitSystem("ERROR: Could not allocate enough memory");
     }
+    memset(GameMemoryPointer, 0, MALLOC_SIZE);
 
     GameAllocMemPointer = GameMemoryPointer;
     GameAllocMemFree = MALLOC_SIZE;


### PR DESCRIPTION
explicitly clear the memory to 0.
GCC does this by default, other compilers don't. MSVC sets it to 0xcdcdcdcd for debugging purposes.

sadly the trigger data in Folly has an invalid item number which is usually fine because it gets an all null, the floor is null and so nothing is called. If this is OG bug, or now manifesting from some other changes I don't know.