### PR TITLE
game/draw: simplify 3d pickup lighting

### DIFF
--- a/src/game/draw.c
+++ b/src/game/draw.c
@@ -462,14 +462,9 @@ void DrawPickupItem(ITEM_INFO *item)
     phd_PushMatrix();
     phd_TranslateAbs(item->pos.x, offset, item->pos.z);
 
-    int16_t *frame = &object->frame_base[(object->nmeshes * 2 + 10)];
-    CalculateObjectLighting(item, frame);
+    S_CalculateLight(item->pos.x, item->pos.y, item->pos.z, item->room_number);
 
-    int32_t x = (PhdMatrixPtr->_03 >> W2V_SHIFT) + item->pos.x;
-    int32_t y = (PhdMatrixPtr->_13 >> W2V_SHIFT) + item->pos.y;
-    int32_t z = (PhdMatrixPtr->_23 >> W2V_SHIFT) + item->pos.z;
-    S_CalculateLight(x, y, z, item->room_number);
-
+    int16_t *frame = &object->frame_base[object->nmeshes * 2 + 10];
     int32_t clip = S_GetObjectBounds(frame);
     if (clip) {
         // From this point on the function is a slightly customised version


### PR DESCRIPTION
`CalculateObjectLighting` in itself calls `S_CalculateLight` so the call underneath felt extraneous. I couldn't get `CalculateObjectLighting` to calculate the light correctly, though, so I just decided to throw mesh and matrix information away and go with just the intensity of the light at the pickup location. Pickups are supposed to be small anyway so it shouldn't matter.

![20211110_152020_abt](https://user-images.githubusercontent.com/1045476/141130921-2df97711-f434-4df5-a81d-120fd1e316fd.png)
![20211110_152216_dyn](https://user-images.githubusercontent.com/1045476/141130922-816b0536-f36d-46db-9ae4-5a84a98298e9.png)
![20211110_152605_pfr](https://user-images.githubusercontent.com/1045476/141130923-8d0e2b61-5e1d-463e-9cc4-a83aa55e98a7.png)
![20211110_151725_ikl](https://user-images.githubusercontent.com/1045476/141130904-36f2f148-f823-44cb-8b25-d4d12672cd03.png)
![20211110_151840_aul](https://user-images.githubusercontent.com/1045476/141130919-5b8f7dcf-1351-4142-895e-38bf08728f97.png)
