### PR TITLE
objects/pickup: make pickup radius broader

### DIFF
--- a/src/game/objects/pickup.c
+++ b/src/game/objects/pickup.c
@@ -13,7 +13,7 @@ PHD_VECTOR PickUpPosition = { 0, 0, -100 };
 PHD_VECTOR PickUpPositionUW = { 0, -200, -350 };
 
 int16_t PickUpBounds[12] = {
-    -256, +256, -100, +100, -256, +100, -10 * PHD_DEGREE, +10 * PHD_DEGREE,
+    -256, +256, -100, +100, -256, +256, -10 * PHD_DEGREE, +10 * PHD_DEGREE,
     0,    0,    0,    0,
 };
 


### PR DESCRIPTION
In TR1 and TR2, possibly in the later games too, Lara has a larger pickup radius if she's facing away from the item. This is counter-intuitive. This commit adjusts it so that the radius is the same regardless of her orientation in reference to the collectibles.

Closes #195