### PR TITLE
ai/evil-lara: fix malformed savegame flags

### DIFF
--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -130,6 +130,12 @@ void File_Seek(MYFILE *file, size_t pos, FILE_SEEK_MODE mode)
     }
 }
 
+size_t File_GetPos(MYFILE *file)
+{
+    assert(file);
+    return ftell(file->fp);
+}
+
 size_t File_Size(MYFILE *file)
 {
     size_t old = ftell(file->fp);

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -29,6 +29,7 @@ size_t File_Write(
     const void *data, size_t item_size, size_t count, MYFILE *file);
 size_t File_Size(MYFILE *file);
 void File_Seek(MYFILE *file, size_t pos, FILE_SEEK_MODE mode);
+size_t File_GetPos(MYFILE *file);
 void File_Close(MYFILE *file);
 int File_Delete(const char *path);
 

--- a/src/game/ai/evil_lara.c
+++ b/src/game/ai/evil_lara.c
@@ -16,7 +16,6 @@ void SetupEvilLara(OBJECT_INFO *obj)
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
-    obj->save_flags = 1;
 }
 
 void InitialiseEvilLara(int16_t item_num)


### PR DESCRIPTION
The main gist of this pull request is the removal of `obj->save_flags = 1;`, the rest are debugging leftovers which are either aesthetic improvements, or useful functions as is the case with `File_GetPos` which I long meant to add.

@walkawayy could you please test, and confirm that the savegame behavior around Bacon Lara is consistent with OG?