### PR TITLE
Make anisotropy filter value configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ lint:
 
 test_base:
 	cp build/*.exe test/
+
+test_bin:
 	rsync -r bin/ test/
 
 test: build test_base
@@ -38,4 +40,4 @@ test: build test_base
 test_gold: build test_base
 	WINEARCH=win32 MESA_GL_VERSION_OVERRIDE=3.3 wine test/Tomb1Main.exe -gold
 
-.PHONY: debug debugopt release clean lint test_base test test_gold
+.PHONY: debug debugopt release clean lint test_base test_bin test test_gold

--- a/bin/cfg/Tomb1Main.json5
+++ b/bin/cfg/Tomb1Main.json5
@@ -186,4 +186,7 @@
 
     // Screenshot file format. Must be either "jpg" or "png".
     "screenshot_format": "jpg",
+
+    // Enhances texture filtering at distances.
+    "anisotropy_filter": 16.0,
 }

--- a/src/config.c
+++ b/src/config.c
@@ -15,7 +15,8 @@
 
 #define READ_PRIMITIVE(func, opt, default_value)                               \
     do {                                                                       \
-        g_Config.opt = func(root_obj, QUOTE(opt), default_value);              \
+        g_Config.opt =                                                         \
+            func(root_obj, Config_ProcessKey(QUOTE(opt)), default_value);      \
     } while (0)
 #define READ_BOOL(opt, default_value)                                          \
     READ_PRIMITIVE(json_object_get_bool, opt, default_value)
@@ -26,8 +27,8 @@
 
 #define READ_ENUM(opt, default_value, enum_map)                                \
     do {                                                                       \
-        g_Config.opt =                                                         \
-            Config_ReadEnum(root_obj, QUOTE(opt), default_value, enum_map);    \
+        g_Config.opt = Config_ReadEnum(                                        \
+            root_obj, Config_ProcessKey(QUOTE(opt)), default_value, enum_map); \
     } while (0)
 
 CONFIG g_Config = { 0 };
@@ -72,6 +73,16 @@ const ENUM_MAP m_ScreenshotFormats[] = {
     { "png", SCREENSHOT_FORMAT_PNG },
     { NULL, -1 },
 };
+
+static const char *Config_ProcessKey(const char *key);
+static int Config_ReadEnum(
+    struct json_object_s *obj, const char *name, int8_t default_value,
+    const ENUM_MAP *enum_map);
+
+static const char *Config_ProcessKey(const char *key)
+{
+    return strchr(key, '.') ? strrchr(key, '.') + 1 : key;
+}
 
 static int Config_ReadEnum(
     struct json_object_s *obj, const char *name, int8_t default_value,
@@ -146,6 +157,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_FLOAT(brightness, 1.0);
     READ_BOOL(enable_round_shadow, true);
     READ_BOOL(enable_3d_pickups, true);
+    READ_FLOAT(rendering.anisotropy_filter, 16.0f);
 
     READ_ENUM(
         healthbar_showing_mode, BSM_FLASHING_OR_DEFAULT, m_BarShowingModes);

--- a/src/config.h
+++ b/src/config.h
@@ -92,6 +92,7 @@ typedef struct {
         uint32_t enable_perspective_filter : 1;
         uint32_t enable_bilinear_filter : 1;
         uint32_t enable_fps_counter : 1;
+        float anisotropy_filter;
     } rendering;
 
     struct {

--- a/src/config.h
+++ b/src/config.h
@@ -89,10 +89,10 @@ typedef struct {
     } input;
 
     struct {
-        uint32_t perspective : 1;
-        uint32_t bilinear : 1;
-        uint32_t fps_counter : 1;
-    } render_flags;
+        uint32_t enable_perspective_filter : 1;
+        uint32_t enable_bilinear_filter : 1;
+        uint32_t enable_fps_counter : 1;
+    } rendering;
 
     struct {
         double text_scale;

--- a/src/game/option_graphics.c
+++ b/src/game/option_graphics.c
@@ -45,14 +45,16 @@ static void Option_GraphicsInitText()
     sprintf(
         buf, g_GameFlow.strings[GS_DETAIL_PERSPECTIVE_FMT],
         g_GameFlow.strings
-            [g_Config.render_flags.perspective ? GS_MISC_ON : GS_MISC_OFF]);
+            [g_Config.rendering.enable_perspective_filter ? GS_MISC_ON
+                                                          : GS_MISC_OFF]);
     m_Text[TEXT_PERSPECTIVE] = Text_Create(0, y, buf);
     y += ROW_HEIGHT;
 
     sprintf(
         buf, g_GameFlow.strings[GS_DETAIL_BILINEAR_FMT],
         g_GameFlow.strings
-            [g_Config.render_flags.bilinear ? GS_MISC_ON : GS_MISC_OFF]);
+            [g_Config.rendering.enable_bilinear_filter ? GS_MISC_ON
+                                                       : GS_MISC_OFF]);
     m_Text[TEXT_BILINEAR] = Text_Create(0, y, buf);
     y += ROW_HEIGHT;
 
@@ -130,15 +132,15 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
     if (g_InputDB.right) {
         switch (g_OptionSelected) {
         case TEXT_PERSPECTIVE:
-            if (!g_Config.render_flags.perspective) {
-                g_Config.render_flags.perspective = 1;
+            if (!g_Config.rendering.enable_perspective_filter) {
+                g_Config.rendering.enable_perspective_filter = 1;
                 reset = true;
             }
             break;
 
         case TEXT_BILINEAR:
-            if (!g_Config.render_flags.bilinear) {
-                g_Config.render_flags.bilinear = 1;
+            if (!g_Config.rendering.enable_bilinear_filter) {
+                g_Config.rendering.enable_bilinear_filter = 1;
                 reset = true;
             }
             break;
@@ -175,15 +177,15 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
     if (g_InputDB.left) {
         switch (g_OptionSelected) {
         case TEXT_PERSPECTIVE:
-            if (g_Config.render_flags.perspective) {
-                g_Config.render_flags.perspective = 0;
+            if (g_Config.rendering.enable_perspective_filter) {
+                g_Config.rendering.enable_perspective_filter = 0;
                 reset = true;
             }
             break;
 
         case TEXT_BILINEAR:
-            if (g_Config.render_flags.bilinear) {
-                g_Config.render_flags.bilinear = 0;
+            if (g_Config.rendering.enable_bilinear_filter) {
+                g_Config.rendering.enable_bilinear_filter = 0;
                 reset = true;
             }
             break;

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -469,7 +469,7 @@ void Overlay_DrawFPSInfo()
 {
     static int32_t elapsed = 0;
 
-    if (g_Config.render_flags.fps_counter) {
+    if (g_Config.rendering.enable_fps_counter) {
         if (Clock_GetMS() - elapsed >= 1000) {
             if (m_FPSText) {
                 char fps_buf[20];

--- a/src/game/settings.c
+++ b/src/game/settings.c
@@ -43,9 +43,9 @@ static bool Settings_ReadFromJSON(const char *cfg_data)
     result = true;
 
     struct json_object_s *root_obj = json_value_as_object(root);
-    g_Config.render_flags.bilinear =
+    g_Config.rendering.enable_bilinear_filter =
         json_object_get_bool(root_obj, "bilinear", true);
-    g_Config.render_flags.perspective =
+    g_Config.rendering.enable_perspective_filter =
         json_object_get_bool(root_obj, "perspective", true);
 
     {
@@ -129,9 +129,9 @@ bool Settings_Write()
     size_t size;
     struct json_object_s *root_obj = json_object_new();
     json_object_append_bool(
-        root_obj, "bilinear", g_Config.render_flags.bilinear);
+        root_obj, "bilinear", g_Config.rendering.enable_bilinear_filter);
     json_object_append_bool(
-        root_obj, "perspective", g_Config.render_flags.perspective);
+        root_obj, "perspective", g_Config.rendering.enable_perspective_filter);
     json_object_append_number_int(
         root_obj, "hi_res", Screen_GetPendingResIdx());
     json_object_append_number_int(

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -1,5 +1,6 @@
 #include "gfx/3d/3d_renderer.h"
 
+#include "config.h"
 #include "gfx/context.h"
 #include "gfx/gl/utils.h"
 
@@ -35,7 +36,8 @@ void GFX_3D_Renderer_Init(GFX_3D_Renderer *renderer)
     GFX_GL_Sampler_Init(&renderer->sampler);
     GFX_GL_Sampler_Bind(&renderer->sampler, 0);
     GFX_GL_Sampler_Parameterf(
-        &renderer->sampler, GL_TEXTURE_MAX_ANISOTROPY_EXT, 16.0f);
+        &renderer->sampler, GL_TEXTURE_MAX_ANISOTROPY_EXT,
+        g_Config.rendering.anisotropy_filter);
 
     GFX_GL_Program_Init(&renderer->program);
     GFX_GL_Program_AttachShader(

--- a/src/specific/s_input.c
+++ b/src/specific/s_input.c
@@ -495,21 +495,21 @@ INPUT_STATE S_Input_GetCurrentState()
     }
 
     if (KEY_DOWN(DIK_F3)) {
-        g_Config.render_flags.bilinear ^= 1;
+        g_Config.rendering.enable_bilinear_filter ^= 1;
         while (KEY_DOWN(DIK_F3)) {
             S_Input_DInput_KeyboardRead();
         }
     }
 
     if (KEY_DOWN(DIK_F4)) {
-        g_Config.render_flags.perspective ^= 1;
+        g_Config.rendering.enable_perspective_filter ^= 1;
         while (KEY_DOWN(DIK_F4)) {
             S_Input_DInput_KeyboardRead();
         }
     }
 
     if (KEY_DOWN(DIK_F2)) {
-        g_Config.render_flags.fps_counter ^= 1;
+        g_Config.rendering.enable_fps_counter ^= 1;
         while (KEY_DOWN(DIK_F2)) {
             S_Input_DInput_KeyboardRead();
         }

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -101,7 +101,7 @@ static void S_Output_SetupRenderContextAndRender()
 {
     S_Output_RenderBegin();
     GFX_3D_Renderer_SetSmoothingEnabled(
-        m_Renderer3D, g_Config.render_flags.bilinear);
+        m_Renderer3D, g_Config.rendering.enable_bilinear_filter);
     S_Output_RenderToggle();
 }
 


### PR DESCRIPTION
The motivation for this PR has two sources:

- TombATI makes it possible to change the anisotropy filter value
- I am facing a problem on wine that makes the game unplayable if there are many textures and the anisotropy filter is enabled