### PR TITLE
gfx: fix garbage value resolutions showing as options

### DIFF
--- a/src/global/const.h
+++ b/src/global/const.h
@@ -212,7 +212,7 @@
 #define SOUND_ACTION 16
 #define VIDEO_ACTION 32
 
-#define RESOLUTIONS_SIZE 12
+#define RESOLUTIONS_SIZE 10
 
 #if _MSC_VER > 0x500
     #define strdup _strdup // fixes error about POSIX function


### PR DESCRIPTION
Tiny resolutions were removed, but `RESOLUTIONS_SIZE` was still set to 12. So, garbage values were showing as resolution options from the sunglasses menu.