### PR TITLE
game: fix top offscreen load game selection

### DIFF
--- a/src/game/game.c
+++ b/src/game/game.c
@@ -288,6 +288,8 @@ void Game_ScanSavedGames()
 
     if (req->requested >= req->vis_lines) {
         req->line_offset = req->requested - req->vis_lines + 1;
+    } else if (req->requested < req->vis_lines - req->line_offset) {
+        req->line_offset = req->requested;
     }
 
     g_SaveCounter++;


### PR DESCRIPTION
Resolves #273.

I was thinking maybe the game should highlight the slot you most recently saved OR loaded instead of the most recent overall one. Idk just something I was thinking of when I was looking at the code.