### PR TITLE
gfx: implement menu backgrounds properly

### DIFF
--- a/src/game/cinema.h
+++ b/src/game/cinema.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 void InitCinematicRooms();
 int32_t StartCinematic(int32_t level_num);
 int32_t StopCinematic(int32_t level_num);
 int32_t CinematicLoop();
-int32_t DoCinematic(int32_t nframes);
+bool DoCinematic(int32_t nframes);
 void CalculateCinematicCamera();
 void ControlCinematicPlayer(int16_t item_num);
 void ControlCinematicPlayer4(int16_t item_num);

--- a/src/game/control.c
+++ b/src/game/control.c
@@ -24,6 +24,7 @@
 #include <stddef.h>
 
 static const int32_t m_AnimationRate = 0x8000;
+static int32_t m_FrameCount = 0;
 
 static void Control_TriggerMusicTrack(
     int16_t track, int16_t flags, int16_t type);
@@ -205,14 +206,13 @@ void CheckCheatMode()
 
 int32_t ControlPhase(int32_t nframes, int32_t demo_mode)
 {
-    static int32_t frame_count = 0;
     int32_t return_val = 0;
     if (nframes > MAX_FRAMES) {
         nframes = MAX_FRAMES;
     }
 
-    frame_count += m_AnimationRate * nframes;
-    while (frame_count >= 0) {
+    m_FrameCount += m_AnimationRate * nframes;
+    while (m_FrameCount >= 0) {
         CheckCheatMode();
         if (g_LevelComplete) {
             return GF_NOP_BREAK;
@@ -325,7 +325,7 @@ int32_t ControlPhase(int32_t nframes, int32_t demo_mode)
             }
         }
 
-        frame_count -= 0x10000;
+        m_FrameCount -= 0x10000;
     }
 
     return GF_NOP;

--- a/src/game/control.c
+++ b/src/game/control.c
@@ -204,7 +204,7 @@ void CheckCheatMode()
     }
 }
 
-int32_t ControlPhase(int32_t nframes, int32_t demo_mode)
+int32_t ControlPhase(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
 {
     int32_t return_val = 0;
     if (nframes > MAX_FRAMES) {
@@ -224,7 +224,7 @@ int32_t ControlPhase(int32_t nframes, int32_t demo_mode)
             return GF_NOP_BREAK;
         }
 
-        if (demo_mode) {
+        if (level_type == GFL_DEMO) {
             if (g_Input.any) {
                 return GF_EXIT_TO_TITLE;
             }
@@ -237,7 +237,7 @@ int32_t ControlPhase(int32_t nframes, int32_t demo_mode)
             || (g_Lara.death_count > DEATH_WAIT_MIN && g_Input.any
                 && !g_Input.fly_cheat)
             || g_OverlayFlag == 2) {
-            if (demo_mode) {
+            if (level_type == GFL_DEMO) {
                 return GF_EXIT_TO_TITLE;
             }
             if (g_OverlayFlag == 2) {

--- a/src/game/control.h
+++ b/src/game/control.h
@@ -4,7 +4,7 @@
 
 #include <stdint.h>
 
-int32_t ControlPhase(int32_t nframes, int32_t demo_mode);
+int32_t ControlPhase(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type);
 void AnimateItem(ITEM_INFO *item);
 int32_t GetChange(ITEM_INFO *item, ANIM_STRUCT *anim);
 void TranslateItem(ITEM_INFO *item, int32_t x, int32_t y, int32_t z);

--- a/src/game/control_pause.c
+++ b/src/game/control_pause.c
@@ -151,7 +151,7 @@ bool Control_Pause()
     g_InvMode = INV_PAUSE_MODE;
 
     Text_RemoveAll();
-    S_FadeInInventory(1);
+    Output_CopyScreenToBuffer();
     Output_SetupAboveWater(false);
 
     Music_Pause();
@@ -163,7 +163,6 @@ bool Control_Pause()
     Music_Unpause();
     RemoveRequester(&m_PauseRequester);
     Control_Pause_RemoveText();
-    S_FadeOutInventory(1);
     g_OverlayFlag = old_overlay_flag;
     return select < 0;
 }

--- a/src/game/demo.c
+++ b/src/game/demo.c
@@ -71,7 +71,7 @@ int32_t StartDemo()
         Text_AlignBottom(txt, 1);
         Text_CentreH(txt, 1);
 
-        GameLoop(1);
+        GameLoop(GFL_DEMO);
 
         Text_Remove(txt);
 

--- a/src/game/draw.c
+++ b/src/game/draw.c
@@ -1351,11 +1351,13 @@ int16_t *GetBestFrame(ITEM_INFO *item)
     }
 }
 
-void Draw_DrawScene()
+void Draw_DrawScene(bool draw_overlay)
 {
     if (g_Objects[O_LARA].loaded) {
         DrawRooms(g_Camera.pos.room_number);
-        Overlay_DrawGameInfo();
+        if (draw_overlay) {
+            Overlay_DrawGameInfo();
+        }
     } else {
         // cinematic scene
         m_CameraUnderwater = false;
@@ -1374,7 +1376,7 @@ void Draw_DrawScene()
 int32_t Draw_ProcessFrame()
 {
     Output_InitialisePolyList();
-    Draw_DrawScene();
+    Draw_DrawScene(true);
     g_Camera.number_frames = Output_DumpScreen();
     Output_AnimateTextures(g_Camera.number_frames);
     return g_Camera.number_frames;

--- a/src/game/draw.c
+++ b/src/game/draw.c
@@ -17,35 +17,6 @@
 static int16_t m_InterpolatedBounds[6] = { 0 };
 static bool m_CameraUnderwater = false;
 
-int32_t DrawPhaseCinematic()
-{
-    Output_InitialisePolyList();
-    Output_ClearScreen();
-    m_CameraUnderwater = false;
-    for (int i = 0; i < g_RoomsToDrawCount; i++) {
-        int16_t room_num = g_RoomsToDraw[i];
-        ROOM_INFO *r = &g_RoomInfo[room_num];
-        r->top = 0;
-        r->left = 0;
-        r->right = ViewPort_GetMaxX();
-        r->bottom = ViewPort_GetMaxY();
-        PrintRooms(room_num);
-    }
-    g_Camera.number_frames = Output_DumpScreen();
-    Output_AnimateTextures(g_Camera.number_frames);
-    return g_Camera.number_frames;
-}
-
-int32_t DrawPhaseGame()
-{
-    Output_InitialisePolyList();
-    DrawRooms(g_Camera.pos.room_number);
-    Overlay_DrawGameInfo();
-    g_Camera.number_frames = Output_DumpScreen();
-    Output_AnimateTextures(g_Camera.number_frames);
-    return g_Camera.number_frames;
-}
-
 void DrawRooms(int16_t current_room)
 {
     g_PhdLeft = ViewPort_GetMinX();
@@ -1378,4 +1349,33 @@ int16_t *GetBestFrame(ITEM_INFO *item)
     } else {
         return frmptr[1];
     }
+}
+
+void Draw_DrawScene()
+{
+    if (g_Objects[O_LARA].loaded) {
+        DrawRooms(g_Camera.pos.room_number);
+        Overlay_DrawGameInfo();
+    } else {
+        // cinematic scene
+        m_CameraUnderwater = false;
+        for (int i = 0; i < g_RoomsToDrawCount; i++) {
+            int16_t room_num = g_RoomsToDraw[i];
+            ROOM_INFO *r = &g_RoomInfo[room_num];
+            r->top = 0;
+            r->left = 0;
+            r->right = ViewPort_GetMaxX();
+            r->bottom = ViewPort_GetMaxY();
+            PrintRooms(room_num);
+        }
+    }
+}
+
+int32_t Draw_ProcessFrame()
+{
+    Output_InitialisePolyList();
+    Draw_DrawScene();
+    g_Camera.number_frames = Output_DumpScreen();
+    Output_AnimateTextures(g_Camera.number_frames);
+    return g_Camera.number_frames;
 }

--- a/src/game/draw.h
+++ b/src/game/draw.h
@@ -4,8 +4,6 @@
 
 #include <stdint.h>
 
-int32_t DrawPhaseCinematic();
-int32_t DrawPhaseGame();
 void DrawRooms(int16_t current_room);
 void GetRoomBounds(int16_t room_num);
 int32_t SetRoomBounds(int16_t *objptr, int16_t room_num, ROOM_INFO *parent);
@@ -26,3 +24,6 @@ void DrawLaraInt(
 int32_t GetFrames(ITEM_INFO *item, int16_t *frmptr[], int32_t *rate);
 int16_t *GetBoundsAccurate(ITEM_INFO *item);
 int16_t *GetBestFrame(ITEM_INFO *item);
+
+void Draw_DrawScene();
+int32_t Draw_ProcessFrame();

--- a/src/game/draw.h
+++ b/src/game/draw.h
@@ -25,5 +25,5 @@ int32_t GetFrames(ITEM_INFO *item, int16_t *frmptr[], int32_t *rate);
 int16_t *GetBoundsAccurate(ITEM_INFO *item);
 int16_t *GetBestFrame(ITEM_INFO *item);
 
-void Draw_DrawScene();
+void Draw_DrawScene(bool draw_overlay);
 int32_t Draw_ProcessFrame();

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -43,7 +43,7 @@ int32_t StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 int32_t StopGame()
 {
     if (g_LevelComplete) {
-        S_FadeInInventory(1);
+        Output_CopyScreenToBuffer();
         return GF_LEVEL_COMPLETE | g_CurrentLevel;
     }
 
@@ -75,7 +75,7 @@ int32_t GameLoop(int32_t demo_mode)
         if (ret != GF_NOP) {
             break;
         }
-        nframes = DrawPhaseGame();
+        nframes = Draw_ProcessFrame();
     }
 
     Sound_StopAllSamples();
@@ -100,7 +100,6 @@ void LevelStats(int32_t level_num)
     char time_str[100];
     TEXTSTRING *txt;
 
-    Screen_ApplyResolution();
     Text_RemoveAll();
 
     // heading

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -6,6 +6,6 @@
 
 int32_t StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
 int32_t StopGame();
-int32_t GameLoop(int32_t demo_mode);
+int32_t GameLoop(GAMEFLOW_LEVEL_TYPE level_type);
 int32_t LevelCompleteSequence(int32_t level_num);
 void LevelStats(int32_t level_num);

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1022,20 +1022,10 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
         switch (seq->type) {
         case GFS_START_GAME:
             ret = StartGame((int32_t)seq->data, level_type);
-            if (g_GameFlow.enable_save_crystals && level_type != GFL_SAVED
-                && (int32_t)seq->data != g_GameFlow.first_level_num
-                && (int32_t)seq->data != g_GameFlow.gym_level_num) {
-                int32_t return_val = Display_Inventory(INV_SAVE_CRYSTAL_MODE);
-                if (return_val != GF_NOP) {
-                    SaveGame_SaveToFile(&g_GameInfo, g_InvExtraData[1]);
-                    Settings_Write();
-                }
-            }
-
             break;
 
         case GFS_LOOP_GAME:
-            ret = GameLoop(0);
+            ret = GameLoop(level_type);
             LOG_DEBUG("GameLoop() exited with %d", ret);
             if (ret != GF_NOP) {
                 return ret;

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -56,13 +56,11 @@ int32_t Display_Inventory(int inv_mode)
     g_InvMode = inv_mode;
 
     m_InvNFrames = 2;
-    Construct_Inventory();
-
     if (g_InvMode != INV_TITLE_MODE) {
-        S_FadeInInventory(1);
-    } else {
-        S_FadeInInventory(0);
+        Screen_ApplyResolution();
+        Output_CopyScreenToBuffer();
     }
+    Construct_Inventory();
 
     Sound_StopAmbientSounds();
     Sound_StopAllSamples();
@@ -277,12 +275,6 @@ int32_t Display_Inventory(int inv_mode)
                     g_InvMainCurrent = ring.current_object;
                 } else {
                     g_InvOptionCurrent = ring.current_object;
-                }
-
-                if (g_InvMode == INV_TITLE_MODE) {
-                    S_FadeOutInventory(0);
-                } else {
-                    S_FadeOutInventory(1);
                 }
 
                 Inv_RingMotionSetup(&ring, RNG_CLOSING, RNG_DONE, CLOSE_FRAMES);
@@ -585,11 +577,6 @@ int32_t Display_Inventory(int inv_mode)
 
         case RNG_EXITING_INVENTORY:
             if (!imo.count) {
-                if (g_InvMode != INV_TITLE_MODE) {
-                    S_FadeOutInventory(1);
-                } else {
-                    S_FadeOutInventory(0);
-                }
                 Inv_RingMotionSetup(&ring, RNG_CLOSING, RNG_DONE, CLOSE_FRAMES);
                 Inv_RingMotionRadius(&ring, 0);
                 Inv_RingMotionCameraPos(&ring, CAMERA_STARTHEIGHT);
@@ -601,7 +588,12 @@ int32_t Display_Inventory(int inv_mode)
     } while (imo.status != RNG_DONE);
 
     RemoveInventoryText();
-    S_FinishInventory();
+
+    if (g_InvMode != INV_TITLE_MODE) {
+        Screen_ApplyResolution();
+    }
+    g_ModeLock = false;
+
     if (m_VersionText) {
         Text_Remove(m_VersionText);
         m_VersionText = NULL;
@@ -708,9 +700,6 @@ int32_t Display_Inventory(int inv_mode)
 void Construct_Inventory()
 {
     Output_SetupAboveWater(false);
-    if (g_InvMode != INV_TITLE_MODE) {
-        Screen_ApplyResolution();
-    }
 
     g_PhdLeft = ViewPort_GetMinX();
     g_PhdTop = ViewPort_GetMinY();

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -649,6 +649,11 @@ void Output_DrawSprite(
     }
 }
 
+void Output_CopyScreenToBuffer()
+{
+    S_Output_CopyToPicture();
+}
+
 void Output_CopyBufferToScreen()
 {
     S_Output_CopyFromPicture();

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -27,6 +27,7 @@ void Output_SetWaterColor(const RGBF *color);
 void Output_ClearScreen();
 void Output_DrawEmpty();
 void Output_InitialisePolyList();
+void Output_CopyScreenToBuffer();
 void Output_CopyBufferToScreen();
 int32_t Output_DumpScreen();
 

--- a/src/gfx/2d/2d_surface.c
+++ b/src/gfx/2d/2d_surface.c
@@ -106,51 +106,20 @@ bool GFX_2D_Surface_Blt(
 
         int32_t depth = surface->desc.bit_count / 8;
 
-        if (src->desc.flags.primary) {
-            // This is a somewhat ugly and slow hack to get a rescaled and
-            // converted copy of the framebuffer for the surface, which is
-            // required to display the in-game menu of Tomb Raider
-            // correctly.
-            GLint width;
-            GLint height;
-            GFX_Screenshot_CaptureToBuffer(
-                NULL, &width, &height, depth, GL_BGRA,
-                GL_UNSIGNED_INT_8_8_8_8_REV, false, true);
-            uint8_t *buffer = Memory_Alloc(width * height * depth);
-            GFX_Screenshot_CaptureToBuffer(
-                buffer, &width, &height, depth, GL_BGRA,
-                GL_UNSIGNED_INT_8_8_8_8_REV, false, true);
+        int32_t src_width = src->desc.width;
+        int32_t src_height = src->desc.height;
+        const GFX_BlitterRect default_src_rect = {
+            .left = 0, .top = 0, .right = src_width, .bottom = src_height
+        };
 
-            for (int i = 0; i < width * height * depth; i++) {
-                buffer[i] /= 2;
-            }
+        GFX_BlitterImage src_img = { src_width, src_height, depth,
+                                     src->buffer };
+        GFX_BlitterImage dst_img = { dst_width, dst_height, depth,
+                                     surface->buffer };
 
-            GFX_BlitterRect src_rect = {
-                .left = 0, .top = height, .right = width, .bottom = 0
-            };
-            GFX_BlitterImage src_img = { width, height, depth, buffer };
-            GFX_BlitterImage dst_img = { dst_width, dst_height, depth,
-                                         surface->buffer };
-            GFX_Blit(
-                &src_img, &src_rect, &dst_img,
-                dst_rect ? dst_rect : &default_dst_rect);
-            Memory_FreePointer(&buffer);
-        } else {
-            int32_t src_width = src->desc.width;
-            int32_t src_height = src->desc.height;
-            const GFX_BlitterRect default_src_rect = {
-                .left = 0, .top = 0, .right = src_width, .bottom = src_height
-            };
-
-            GFX_BlitterImage src_img = { src_width, src_height, depth,
-                                         src->buffer };
-            GFX_BlitterImage dst_img = { dst_width, dst_height, depth,
-                                         surface->buffer };
-
-            GFX_Blit(
-                &src_img, src_rect ? src_rect : &default_src_rect, &dst_img,
-                dst_rect ? dst_rect : &default_dst_rect);
-        }
+        GFX_Blit(
+            &src_img, src_rect ? src_rect : &default_src_rect, &dst_img,
+            dst_rect ? dst_rect : &default_dst_rect);
     }
 
     return true;

--- a/src/gfx/screenshot.c
+++ b/src/gfx/screenshot.c
@@ -13,7 +13,7 @@ bool GFX_Screenshot_CaptureToFile(const char *path)
     GLint width;
     GLint height;
     GFX_Screenshot_CaptureToBuffer(
-        NULL, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE, true, false);
+        NULL, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE, true);
 
     PICTURE *pic = Picture_Create();
     if (!pic) {
@@ -25,7 +25,7 @@ bool GFX_Screenshot_CaptureToFile(const char *path)
 
     GFX_Screenshot_CaptureToBuffer(
         (uint8_t *)pic->data, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE,
-        true, false);
+        true);
 
     ret = Picture_SaveToFile(pic, path);
 
@@ -38,7 +38,7 @@ cleanup:
 
 void GFX_Screenshot_CaptureToBuffer(
     uint8_t *out_buffer, GLint *out_width, GLint *out_height, GLint depth,
-    GLenum format, GLenum type, bool vflip, bool front_buffer)
+    GLenum format, GLenum type, bool vflip)
 {
     assert(out_width);
     assert(out_height);
@@ -60,8 +60,7 @@ void GFX_Screenshot_CaptureToBuffer(
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-    // NOTE: GL_FRONT does not work on Intel cards and on Wine
-    glReadBuffer(front_buffer ? GL_FRONT : GL_BACK);
+    glReadBuffer(GL_BACK);
     glReadPixels(x, y, *out_width, *out_height, format, type, out_buffer);
 
     if (vflip) {

--- a/src/gfx/screenshot.h
+++ b/src/gfx/screenshot.h
@@ -8,4 +8,4 @@ bool GFX_Screenshot_CaptureToFile(const char *path);
 
 void GFX_Screenshot_CaptureToBuffer(
     uint8_t *out_buffer, GLint *out_width, GLint *out_height, GLint depth,
-    GLenum format, GLenum type, bool vflip, bool front_buffer);
+    GLenum format, GLenum type, bool vflip);

--- a/src/specific/s_misc.c
+++ b/src/specific/s_misc.c
@@ -9,26 +9,6 @@
 
 #include <string.h>
 
-void S_FadeInInventory(int32_t fade)
-{
-    if (g_CurrentLevel != g_GameFlow.title_level_num) {
-        S_Output_CopyToPicture();
-    }
-}
-
-void S_FadeOutInventory(int32_t fade)
-{
-    // not implemented in TombATI
-}
-
-void S_FinishInventory()
-{
-    if (g_InvMode != INV_TITLE_MODE) {
-        Screen_ApplyResolution();
-    }
-    g_ModeLock = false;
-}
-
 int S_GetObjectBounds(int16_t *bptr)
 {
     if (g_PhdMatrixPtr->_23 >= Output_GetFarZ()) {

--- a/src/specific/s_misc.h
+++ b/src/specific/s_misc.h
@@ -4,8 +4,4 @@
 
 // TODO: these do not belong to specific/ and are badly named
 
-void S_FadeInInventory(int32_t fade);
-void S_FadeOutInventory(int32_t fade);
-void S_FinishInventory();
-
 int S_GetObjectBounds(int16_t *bptr);

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -668,7 +668,7 @@ void S_Output_CopyToPicture()
     // it needs to be drawn again.
 
     S_Output_RenderBegin();
-    Draw_DrawScene();
+    Draw_DrawScene(false);
     S_Output_RenderEnd();
 
     if (!m_PictureSurface) {

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -2,6 +2,7 @@
 
 #include "3dsystem/3d_gen.h"
 #include "config.h"
+#include "game/draw.h"
 #include "game/output.h"
 #include "game/screen.h"
 #include "game/shell.h"
@@ -9,9 +10,11 @@
 #include "gfx/2d/2d_surface.h"
 #include "gfx/3d/3d_renderer.h"
 #include "gfx/context.h"
+#include "gfx/screenshot.h"
 #include "global/vars.h"
 #include "global/vars_platform.h"
 #include "log.h"
+#include "memory.h"
 
 #include <assert.h>
 
@@ -50,8 +53,6 @@ static void S_Output_SetHardwareVideoMode();
 static void S_Output_SetupRenderContextAndRender();
 static void S_Output_ReleaseTextures();
 static void S_Output_ReleaseSurfaces();
-static void S_Output_BlitSurface(
-    GFX_2D_Surface *source, GFX_2D_Surface *target);
 static void S_Output_FlipPrimaryBuffer();
 static void S_Output_ClearSurface(GFX_2D_Surface *surface);
 static void S_Output_DrawTriangleStrip(GFX_3D_Vertex *vertices, int num);
@@ -140,18 +141,6 @@ static void S_Output_ReleaseSurfaces()
         GFX_2D_Surface_Free(m_PictureSurface);
         m_PictureSurface = NULL;
     }
-}
-
-static void S_Output_BlitSurface(GFX_2D_Surface *source, GFX_2D_Surface *target)
-{
-    GFX_BlitterRect rect = {
-        .left = 0,
-        .top = 0,
-        .right = m_SurfaceWidth,
-        .bottom = m_SurfaceHeight,
-    };
-    bool result = GFX_2D_Surface_Blt(target, &rect, source, &rect);
-    S_Output_CheckError(result);
 }
 
 static void S_Output_FlipPrimaryBuffer()
@@ -674,6 +663,14 @@ void S_Output_DrawEmpty()
 
 void S_Output_CopyToPicture()
 {
+    // This function is called BEFORE the scene is rendered, which means the
+    // gl buffer is empty. In order to capture the scene to the picture buffer,
+    // it needs to be drawn again.
+
+    S_Output_RenderBegin();
+    Draw_DrawScene();
+    S_Output_RenderEnd();
+
     if (!m_PictureSurface) {
         GFX_2D_SurfaceDesc surface_desc = {
             .width = m_SurfaceWidth,
@@ -682,8 +679,38 @@ void S_Output_CopyToPicture()
         m_PictureSurface = GFX_2D_Surface_Create(&surface_desc);
     }
 
-    S_Output_RenderEnd();
-    S_Output_BlitSurface(m_BackSurface, m_PictureSurface);
+    GLint width;
+    GLint height;
+    GFX_Screenshot_CaptureToBuffer(
+        NULL, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE, true);
+
+    PICTURE *pic = Picture_Create();
+    if (!pic) {
+        goto cleanup;
+    }
+    pic->width = width;
+    pic->height = height;
+    pic->data = Memory_Alloc(width * height * 3);
+
+    GFX_Screenshot_CaptureToBuffer(
+        (uint8_t *)pic->data, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE,
+        true);
+
+    // dim the captured screen
+    for (int i = 0; i < width * height; i++) {
+        pic->data[i].r /= 2;
+        pic->data[i].g /= 2;
+        pic->data[i].b /= 2;
+    }
+
+    S_Output_DownloadPicture(pic);
+
+cleanup:
+    if (pic) {
+        Picture_Free(pic);
+        pic = NULL;
+    }
+
     S_Output_RenderToggle();
 }
 
@@ -691,7 +718,17 @@ void S_Output_CopyFromPicture()
 {
     S_Output_ClearBackBuffer();
     S_Output_RenderEnd();
-    S_Output_BlitSurface(m_PictureSurface, m_BackSurface);
+
+    GFX_BlitterRect rect = {
+        .left = 0,
+        .top = 0,
+        .right = m_SurfaceWidth,
+        .bottom = m_SurfaceHeight,
+    };
+    bool result =
+        GFX_2D_Surface_Blt(m_BackSurface, &rect, m_PictureSurface, &rect);
+    S_Output_CheckError(result);
+
     S_Output_RenderToggle();
 }
 


### PR DESCRIPTION
First, some context. The main game loop looks like this:

1. Move things around, run game logic (ControlPhase)
2. Draw things (DrawPhase) to the back buffer
3. Move the back buffer to the front buffer (technically we call it flipping buffers, but support for reading from the backbuffer after a flip is fragmentary, so we cannot rely on the "flip" property).

Sometimes step 1 causes additional drawing. One of such examples is the inventory and the pause screen – if the player decides to open them during ControlPhase, the game runs internal loops within ControlPhase.

To display the main menu, currently the game calls `glReadPixels()` from the GL_FRONT buffer. This is bad, because support for reading from the front buffer is fragmentary and varies between GPU vendors. **This pull request changes `glReadPixels()` to read from the back buffer instead.** Now if we ended here, it would be bad for two reasons: first, calls to this happen after page flip from the previous frame. This means we'd be trying to read the back buffer from 2 frames ago. Not only is this ugly, but also like I mentioned previously it is unreliable.

So to that end we also **draw the scene again**. So now the flow looks like this:

1. ControlPhase
2. Player hits <kbd>Esc</kbd>
3. DrawPhase
4. Page flip
5. ControlPhase
6. Enter drawing the inventory
7. Draw the scene (rooms, Lara, objects etc.)
8. Capture the drawn scene to the picture buffer
9. Inventory loop: interaction, rendering, page flips… with backdrop from the picture buffer
10. Player interacts with the inventory, decides to get back to the game
11. DrawPhase
12. Page flip

Not only this resolves #324 it also fixes backdrops on Wine and Intel GPUs which do not support glReadPixels() from GL_FRONT buffer. The penalty is the additional cost of rendering the extra frame.

I needed to add a couple of additional changes having the following things in mind:

- `Screen_ApplyResolution` clears the picture buffer, so we cannot call it after capturing the scene.
- Cinematic scenes are drawn a bit differently so I needed to do some refactors related to this (specifically they list the rooms to draw in a different way than the regular game).
- Cinematic scenes must end one frame early, otherwise the final draw for the scene capture at the end of the loop attempts to draw non-existing animation frames.