### PR TITLE
input: fix certain inputs skipping too many things

### DIFF
--- a/src/game/cinema.c
+++ b/src/game/cinema.c
@@ -83,7 +83,7 @@ bool DoCinematic(int32_t nframes)
         }
 
         Input_Update();
-        if (g_Input.option) {
+        if (g_InputDB.deselect || g_InputDB.select) {
             return true;
         }
 

--- a/src/game/control.c
+++ b/src/game/control.c
@@ -251,7 +251,7 @@ int32_t ControlPhase(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
             }
         }
 
-        if ((g_Input.option || g_Input.save || g_Input.load
+        if ((g_InputDB.option || g_Input.save || g_Input.load
              || g_OverlayFlag <= 0)
             && !g_Lara.death_count) {
             if (g_OverlayFlag > 0) {

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -171,18 +171,8 @@ void LevelStats(int32_t level_num)
     Text_CentreH(txt, 1);
     Text_CentreV(txt, 1);
 
-    // wait till action key release
-    while (g_Input.select || g_Input.deselect) {
-        Input_Update();
-        Output_InitialisePolyList();
-        Output_CopyBufferToScreen();
-        Input_Update();
-        Text_Draw();
-        Output_DumpScreen();
-    }
-
-    // wait till action or escape key press
-    while (!g_Input.select && !g_Input.deselect) {
+    // wait till a skip key is pressed
+    do {
         if (g_ResetFlag) {
             break;
         }
@@ -191,16 +181,7 @@ void LevelStats(int32_t level_num)
         Input_Update();
         Text_Draw();
         Output_DumpScreen();
-    }
-
-    // wait till escape key release
-    while (g_Input.deselect) {
-        Output_InitialisePolyList();
-        Output_CopyBufferToScreen();
-        Input_Update();
-        Text_Draw();
-        Output_DumpScreen();
-    }
+    } while (!g_InputDB.select && !g_InputDB.deselect);
 
     if (level_num == g_GameFlow.last_level_num) {
         g_GameInfo.bonus_flag = GBF_NGPLUS;

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -180,13 +180,10 @@ void Shell_Wait(int nticks)
 {
     for (int i = 0; i < nticks; i++) {
         Input_Update();
-        if (g_Input.any) {
+        if (g_InputDB.any) {
             break;
         }
         Clock_SyncTicks(1);
-    }
-    while (g_Input.any) {
-        Input_Update();
     }
 }
 

--- a/src/specific/s_fmv.c
+++ b/src/specific/s_fmv.c
@@ -161,7 +161,6 @@ typedef struct VideoState {
     SDL_Thread *read_tid;
     AVInputFormat *iformat;
     bool abort_request;
-    bool abort_request_pending;
     bool force_refresh;
     bool paused;
     bool last_paused;
@@ -2154,10 +2153,7 @@ static void S_FMV_RefreshLoopWaitEvent(VideoState *is, SDL_Event *event)
                event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT)) {
 
         Input_Update();
-        if (g_Input.deselect || g_Input.select) {
-            is->abort_request_pending = true;
-        } else if (is->abort_request_pending) {
-            is->abort_request_pending = false;
+        if (g_InputDB.deselect || g_InputDB.select) {
             is->abort_request = true;
         }
 

--- a/src/specific/s_fmv.c
+++ b/src/specific/s_fmv.c
@@ -2187,11 +2187,6 @@ static void S_FMV_EventLoop(VideoState *is)
                 break;
             }
 
-            if (event.key.keysym.sym == SDLK_ESCAPE) {
-                is->abort_request = true;
-                break;
-            }
-
             if (event.key.keysym.sym == SDLK_RETURN
                 && event.key.keysym.mod & KMOD_LALT) {
                 S_Shell_ToggleFullscreen();


### PR DESCRIPTION
Resolves #359.

Scenarios needed to be tested:

(Escape key)

- [x] Holding the Escape key when transitioning from the game screen to the level stats screen.  
      This should trigger inventory on the frame before, and skip the level stats screen on the frame after. Hard to test and can be assumed to work correctly.
- [x] Holding the Escape key when transitioning from the game screen to an FMV.  
      This should trigger inventory on the frame before, and skip the FMV on the frame after. Hard to test and can be assumed to work correctly.
- [x] Holding the Escape key when transitioning from an FMV to the game.  
      Should skip the FMV immediately and then should not trigger the inventory ring.
- [ ] Holding the Escape key when transitioning from an FMV to the level stats screen.  
      Should skip the FMV immediately and then not skip the level stats screen until another key is pressed. (scenario not in vanilla TR1)
- [x] Holding the Escape key when transitioning from the level stats screen to an FMV.
      Should skip the level stats screen immediately and then not skip the FMV until another key is pressed.
- [x] Holding the Escape key when transitioning from the level stats screen to the game.  
      Should skip the FMV immediately and then should not trigger the inventory ring.
- [x] Holding the escape key when transitioning from a cutscene to the level stats screen.
      Should skip the cutscene immediately and then should not skip the level stats screen until another key is pressed.

(Action key)

- [x] Holding the Action key when transitioning from the game screen to an FMV.  
      This should not skip the FMV until another key is pressed.
- [x] Holding the Action key when transitioning from the game screen to the level stats screen.  
      This should not skip the level stats screen until another key is pressed.
- [x] Holding the Action key when transitioning from an FMV to the game.  
      Should skip the FMV immediately and then should make Lara immediately grab or shoot her guns.
- [ ] Holding the Action key when transitioning from an FMV to the level stats screen.  
      Should skip the FMV immediately and then not skip the level stats screen until another key is pressed. (scenario not in vanilla TR1)
- [x] Holding the Action key when transitioning from the level stats screen to an FMV.
      Should skip the level stats screen immediately and then not skip the FMV until another key is pressed.
- [x] Holding the Action key when transitioning from the level stats screen to the game.  
      Should skip the FMV immediately and then should make Lara immediately grab or shoot her guns.
- [x] Holding the escape key when transitioning from a cutscene to the level stats screen.
      Should skip the cutscene immediately and then should not skip the level stats screen until another key is pressed.