### PR TITLE
Improve overlays

### DIFF
--- a/src/game/cinema.c
+++ b/src/game/cinema.c
@@ -47,7 +47,6 @@ int32_t StopCinematic(int32_t level_num)
     Sound_StopAllSamples();
 
     g_LevelComplete = true;
-    Output_CopyScreenToBuffer();
 
     return level_num | GF_LEVEL_COMPLETE;
 }
@@ -74,11 +73,7 @@ bool DoCinematic(int32_t nframes)
 {
     m_FrameCount += m_CinematicAnimationRate * nframes;
     while (m_FrameCount >= 0) {
-        // End the cinematic one frame early (the last frame is handled by
-        // Output_CopyScreenToBuffer). Not doing this causes
-        // Output_CopyScreenToBuffer to attempt rendering non-existing
-        // animation frames.
-        if (g_CineFrame >= g_NumCineFrames - 1) {
+        if (g_CineFrame >= g_NumCineFrames) {
             return true;
         }
 

--- a/src/game/control_pause.c
+++ b/src/game/control_pause.c
@@ -1,5 +1,6 @@
 #include "game/control.h"
 
+#include "game/draw.h"
 #include "game/gameflow.h"
 #include "game/input.h"
 #include "game/music.h"
@@ -94,8 +95,9 @@ static int32_t Control_Pause_Loop()
     int32_t state = 0;
 
     while (1) {
-        Output_InitialisePolyList(0);
-        Output_CopyBufferToScreen();
+        Output_InitialisePolyList();
+        Draw_DrawScene(false);
+        Draw_DrawOverlayBackground();
         Control_Pause_DisplayText();
         Text_Draw();
         Output_DumpScreen();
@@ -150,7 +152,6 @@ bool Control_Pause()
     g_OverlayFlag = -3;
 
     Text_RemoveAll();
-    Output_CopyScreenToBuffer();
     Output_SetupAboveWater(false);
 
     Music_Pause();

--- a/src/game/draw.c
+++ b/src/game/draw.c
@@ -1381,3 +1381,14 @@ int32_t Draw_ProcessFrame()
     Output_AnimateTextures(g_Camera.number_frames);
     return g_Camera.number_frames;
 }
+
+void Draw_DrawOverlayBackground()
+{
+    int32_t sx = 0;
+    int32_t sy = 0;
+    int32_t sw = ViewPort_GetMaxX();
+    int32_t sh = ViewPort_GetMaxY();
+
+    RGBA8888 background = { 0, 0, 0, 128 };
+    Output_DrawScreenFlatQuad(sx, sy, sw, sh, background);
+}

--- a/src/game/draw.h
+++ b/src/game/draw.h
@@ -26,4 +26,5 @@ int16_t *GetBoundsAccurate(ITEM_INFO *item);
 int16_t *GetBestFrame(ITEM_INFO *item);
 
 void Draw_DrawScene(bool draw_overlay);
+void Draw_DrawOverlayBackground();
 int32_t Draw_ProcessFrame();

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -45,7 +45,6 @@ int32_t StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 int32_t StopGame()
 {
     if (g_LevelComplete) {
-        Output_CopyScreenToBuffer();
         return GF_LEVEL_COMPLETE | g_CurrentLevel;
     }
 
@@ -177,7 +176,8 @@ void LevelStats(int32_t level_num)
             break;
         }
         Output_InitialisePolyList();
-        Output_CopyBufferToScreen();
+        Draw_DrawScene(false);
+        Draw_DrawOverlayBackground();
         Input_Update();
         Text_Draw();
         Output_DumpScreen();

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1084,7 +1084,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
                 GAMEFLOW_DISPLAY_PICTURE_DATA *data = seq->data;
                 Output_DisplayPicture(data->path);
                 Output_InitialisePolyList();
-                Output_CopyBufferToScreen();
+                Output_CopyPictureToScreen();
                 Output_DumpScreen();
                 Shell_Wait(data->display_time);
                 Output_FadeToBlack();

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -833,7 +833,8 @@ void DrawInventoryItem(INVENTORY_ITEM *inv_item)
                 case SHAPE_LINE:
                     Output_DrawScreenLine(
                         sx + spr->x, sy + spr->y, spr->param1, spr->param2,
-                        Output_GetPaletteColor((uint8_t)spr->sprnum));
+                        Output_RGB2RGBA(
+                            Output_GetPaletteColor((uint8_t)spr->sprnum)));
                     break;
                 case SHAPE_BOX:
                     Output_DrawScreenBox(

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -395,6 +395,11 @@ RGB888 Output_GetPaletteColor(uint8_t idx)
     return S_Output_GetPaletteColor(idx);
 }
 
+void Output_ClearDepth()
+{
+    S_Output_ClearDepthBuffer();
+}
+
 void Output_ClearScreen()
 {
     S_Output_ClearBackBuffer();
@@ -647,12 +652,7 @@ void Output_DrawSprite(
     }
 }
 
-void Output_CopyScreenToBuffer()
-{
-    S_Output_CopyToPicture();
-}
-
-void Output_CopyBufferToScreen()
+void Output_CopyPictureToScreen()
 {
     S_Output_CopyFromPicture();
 }

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -379,6 +379,12 @@ void Output_DownloadTextures(int page_count)
     S_Output_DownloadTextures(page_count);
 }
 
+RGBA8888 Output_RGB2RGBA(const RGB888 color)
+{
+    RGBA8888 ret = { .r = color.r, .g = color.g, .b = color.b, .a = 255 };
+    return ret;
+}
+
 void Output_SetPalette(RGB888 palette[256])
 {
     S_Output_SetPalette(palette);
@@ -652,28 +658,28 @@ void Output_CopyBufferToScreen()
 }
 
 void Output_DrawScreenFlatQuad(
-    int32_t sx, int32_t sy, int32_t w, int32_t h, RGB888 color)
+    int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA8888 color)
 {
     S_Output_Draw2DQuad(sx, sy, sx + w, sy + h, color, color, color, color);
 }
 
 void Output_DrawScreenGradientQuad(
-    int32_t sx, int32_t sy, int32_t w, int32_t h, RGB888 tl, RGB888 tr,
-    RGB888 bl, RGB888 br)
+    int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA8888 tl, RGBA8888 tr,
+    RGBA8888 bl, RGBA8888 br)
 {
     S_Output_Draw2DQuad(sx, sy, sx + w, sy + h, tl, tr, bl, br);
 }
 
 void Output_DrawScreenLine(
-    int32_t sx, int32_t sy, int32_t w, int32_t h, RGB888 col)
+    int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA8888 col)
 {
     S_Output_Draw2DLine(sx, sy, sx + w, sy + h, col, col);
 }
 
 void Output_DrawScreenBox(int32_t sx, int32_t sy, int32_t w, int32_t h)
 {
-    RGB888 rgb_border_light = Output_GetPaletteColor(15);
-    RGB888 rgb_border_dark = Output_GetPaletteColor(31);
+    RGBA8888 rgb_border_light = Output_RGB2RGBA(Output_GetPaletteColor(15));
+    RGBA8888 rgb_border_dark = Output_RGB2RGBA(Output_GetPaletteColor(31));
     Output_DrawScreenLine(sx - 1, sy - 1, w + 3, 0, rgb_border_light);
     Output_DrawScreenLine(sx, sy, w + 1, 0, rgb_border_dark);
     Output_DrawScreenLine(w + sx + 1, sy, 0, h + 1, rgb_border_light);

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -25,11 +25,11 @@ void Output_SetDrawDistFade(int32_t dist);
 void Output_SetDrawDistMax(int32_t dist);
 void Output_SetWaterColor(const RGBF *color);
 
+void Output_ClearDepth();
 void Output_ClearScreen();
 void Output_DrawEmpty();
 void Output_InitialisePolyList();
-void Output_CopyScreenToBuffer();
-void Output_CopyBufferToScreen();
+void Output_CopyPictureToScreen();
 int32_t Output_DumpScreen();
 
 void Output_CalculateLight(int32_t x, int32_t y, int32_t z, int16_t room_num);

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -12,6 +12,7 @@ void Output_SetFullscreen(bool fullscreen);
 void Output_ApplyResolution();
 void Output_DownloadTextures(int page_count);
 
+RGBA8888 Output_RGB2RGBA(const RGB888 color);
 void Output_SetPalette(RGB888 palette[256]);
 RGB888 Output_GetPaletteColor(uint8_t idx);
 
@@ -44,12 +45,14 @@ void Output_DrawLightningSegment(
     int32_t width);
 
 void Output_DrawScreenFlatQuad(
-    int32_t sx, int32_t sy, int32_t w, int32_t h, RGB888 color);
+    int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA8888 color);
+void Output_DrawScreenTranslucentQuad(
+    int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA8888 color);
 void Output_DrawScreenGradientQuad(
-    int32_t sx, int32_t sy, int32_t w, int32_t h, RGB888 tl, RGB888 tr,
-    RGB888 bl, RGB888 br);
+    int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA8888 tl, RGBA8888 tr,
+    RGBA8888 bl, RGBA8888 br);
 void Output_DrawScreenLine(
-    int32_t sx, int32_t sy, int32_t w, int32_t h, RGB888 col);
+    int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA8888 col);
 void Output_DrawScreenBox(int32_t sx, int32_t sy, int32_t w, int32_t h);
 void Output_DrawScreenFBox(int32_t sx, int32_t sy, int32_t w, int32_t h);
 

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -22,61 +22,61 @@ static TEXTSTRING *m_FPSText = NULL;
 static int16_t m_BarOffsetY[6] = { 0 };
 static DISPLAYPU m_Pickups[MAX_PICKUPS] = { 0 };
 
-static RGB888 m_ColorBarMap[][COLOR_STEPS] = {
+static RGBA8888 m_ColorBarMap[][COLOR_STEPS] = {
     // gold
-    { { 112, 92, 44 },
-      { 164, 120, 72 },
-      { 112, 92, 44 },
-      { 88, 68, 0 },
-      { 80, 48, 20 } },
+    { { 112, 92, 44, 255 },
+      { 164, 120, 72, 255 },
+      { 112, 92, 44, 255 },
+      { 88, 68, 0, 255 },
+      { 80, 48, 20, 255 } },
     // blue
-    { { 100, 116, 100 },
-      { 92, 160, 156 },
-      { 100, 116, 100 },
-      { 76, 80, 76 },
-      { 48, 48, 48 } },
+    { { 100, 116, 100, 255 },
+      { 92, 160, 156, 255 },
+      { 100, 116, 100, 255 },
+      { 76, 80, 76, 255 },
+      { 48, 48, 48, 255 } },
     // grey
-    { { 88, 100, 88 },
-      { 116, 132, 116 },
-      { 88, 100, 88 },
-      { 76, 80, 76 },
-      { 48, 48, 48 } },
+    { { 88, 100, 88, 255 },
+      { 116, 132, 116, 255 },
+      { 88, 100, 88, 255 },
+      { 76, 80, 76, 255 },
+      { 48, 48, 48, 255 } },
     // red
-    { { 160, 40, 28 },
-      { 184, 44, 32 },
-      { 160, 40, 28 },
-      { 124, 32, 32 },
-      { 84, 20, 32 } },
+    { { 160, 40, 28, 255 },
+      { 184, 44, 32, 255 },
+      { 160, 40, 28, 255 },
+      { 124, 32, 32, 255 },
+      { 84, 20, 32, 255 } },
     // silver
-    { { 150, 150, 150 },
-      { 230, 230, 230 },
-      { 200, 200, 200 },
-      { 140, 140, 140 },
-      { 100, 100, 100 } },
+    { { 150, 150, 150, 255 },
+      { 230, 230, 230, 255 },
+      { 200, 200, 200, 255 },
+      { 140, 140, 140, 255 },
+      { 100, 100, 100, 255 } },
     // green
-    { { 100, 190, 20 },
-      { 130, 230, 30 },
-      { 100, 190, 20 },
-      { 90, 150, 15 },
-      { 80, 110, 10 } },
+    { { 100, 190, 20, 255 },
+      { 130, 230, 30, 255 },
+      { 100, 190, 20, 255 },
+      { 90, 150, 15, 255 },
+      { 80, 110, 10, 255 } },
     // gold2
-    { { 220, 170, 0 },
-      { 255, 200, 0 },
-      { 220, 170, 0 },
-      { 185, 140, 0 },
-      { 150, 100, 0 } },
+    { { 220, 170, 0, 255 },
+      { 255, 200, 0, 255 },
+      { 220, 170, 0, 255 },
+      { 185, 140, 0, 255 },
+      { 150, 100, 0, 255 } },
     // blue2
-    { { 0, 170, 220 },
-      { 0, 200, 255 },
-      { 0, 170, 220 },
-      { 0, 140, 185 },
-      { 0, 100, 150 } },
+    { { 0, 170, 220, 255 },
+      { 0, 200, 255, 255 },
+      { 0, 170, 220, 255 },
+      { 0, 140, 185, 255 },
+      { 0, 100, 150, 255 } },
     // pink
-    { { 220, 140, 170 },
-      { 255, 150, 200 },
-      { 210, 130, 160 },
-      { 165, 100, 120 },
-      { 120, 60, 70 } },
+    { { 220, 140, 170, 255 },
+      { 255, 150, 200, 255 },
+      { 210, 130, 160, 255 },
+      { 165, 100, 120, 255 },
+      { 120, 60, 70, 255 } },
 };
 
 typedef struct BAR_INFO {
@@ -201,9 +201,9 @@ static void Overlay_BarGetLocation(
 
 static void Overlay_BarDraw(BAR_INFO *bar_info)
 {
-    const RGB888 rgb_bgnd = { 0, 0, 0 };
-    const RGB888 rgb_border_light = { 128, 128, 128 };
-    const RGB888 rgb_border_dark = { 64, 64, 64 };
+    const RGBA8888 rgb_bgnd = { 0, 0, 0, 255 };
+    const RGBA8888 rgb_border_light = { 128, 128, 128, 255 };
+    const RGBA8888 rgb_border_dark = { 64, 64, 64, 255 };
 
     int32_t width = 100;
     int32_t height = 5;
@@ -245,15 +245,15 @@ static void Overlay_BarDraw(BAR_INFO *bar_info)
 
         if (g_Config.enable_smooth_bars) {
             for (int i = 0; i < COLOR_STEPS - 1; i++) {
-                RGB888 c1 = m_ColorBarMap[bar_info->color][i];
-                RGB888 c2 = m_ColorBarMap[bar_info->color][i + 1];
+                RGBA8888 c1 = m_ColorBarMap[bar_info->color][i];
+                RGBA8888 c2 = m_ColorBarMap[bar_info->color][i + 1];
                 int32_t lsy = sy + i * sh / (COLOR_STEPS - 1);
                 int32_t lsh = sy + (i + 1) * sh / (COLOR_STEPS - 1) - lsy;
                 Output_DrawScreenGradientQuad(sx, lsy, sw, lsh, c1, c1, c2, c2);
             }
         } else {
             for (int i = 0; i < COLOR_STEPS; i++) {
-                RGB888 color = m_ColorBarMap[bar_info->color][i];
+                RGBA8888 color = m_ColorBarMap[bar_info->color][i];
                 int32_t lsy = sy + i * sh / COLOR_STEPS;
                 int32_t lsh = sy + (i + 1) * sh / COLOR_STEPS - lsy;
                 Output_DrawScreenFlatQuad(sx, lsy, sw, lsh, color);

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -138,6 +138,11 @@ void GFX_3D_Renderer_RenderEnd(GFX_3D_Renderer *renderer)
     GFX_GL_CheckError();
 }
 
+void GFX_3D_Renderer_ClearDepth(GFX_3D_Renderer *renderer)
+{
+    glClear(GL_DEPTH_BUFFER_BIT);
+}
+
 int GFX_3D_Renderer_TextureReg(
     GFX_3D_Renderer *renderer, const void *data, int width, int height)
 {

--- a/src/gfx/3d/3d_renderer.h
+++ b/src/gfx/3d/3d_renderer.h
@@ -31,6 +31,7 @@ void GFX_3D_Renderer_Close(GFX_3D_Renderer *renderer);
 
 void GFX_3D_Renderer_RenderBegin(GFX_3D_Renderer *renderer);
 void GFX_3D_Renderer_RenderEnd(GFX_3D_Renderer *renderer);
+void GFX_3D_Renderer_ClearDepth(GFX_3D_Renderer *renderer);
 
 int GFX_3D_Renderer_TextureReg(
     GFX_3D_Renderer *renderer, const void *data, int width, int height);

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1156,6 +1156,13 @@ typedef struct RGB888 {
     uint8_t b;
 } RGB888;
 
+typedef struct RGBA8888 {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+    uint8_t a;
+} RGBA8888;
+
 typedef struct POS_2D {
     uint16_t x;
     uint16_t y;

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -507,6 +507,11 @@ void S_Output_DumpScreen()
     m_SelectedTexture = -1;
 }
 
+void S_Output_ClearDepthBuffer()
+{
+    GFX_3D_Renderer_ClearDepth(m_Renderer3D);
+}
+
 void S_Output_ClearBackBuffer()
 {
     S_Output_RenderEnd();
@@ -517,54 +522,6 @@ void S_Output_ClearBackBuffer()
 void S_Output_DrawEmpty()
 {
     GFX_3D_Renderer_RenderEmpty();
-}
-
-void S_Output_CopyToPicture()
-{
-    // This function is called BEFORE the scene is rendered, which means the
-    // gl buffer is empty. In order to capture the scene to the picture buffer,
-    // it needs to be drawn again.
-
-    S_Output_RenderBegin();
-    Draw_DrawScene(false);
-    S_Output_RenderEnd();
-
-    if (!m_PictureSurface) {
-        GFX_2D_SurfaceDesc surface_desc = {
-            .width = m_SurfaceWidth,
-            .height = m_SurfaceHeight,
-        };
-        m_PictureSurface = GFX_2D_Surface_Create(&surface_desc);
-    }
-
-    GLint width;
-    GLint height;
-    GFX_Screenshot_CaptureToBuffer(
-        NULL, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE, true);
-
-    PICTURE *pic = Picture_Create(width, height);
-    assert(pic);
-
-    GFX_Screenshot_CaptureToBuffer(
-        (uint8_t *)pic->data, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE,
-        true);
-
-    // dim the captured screen
-    for (int i = 0; i < width * height; i++) {
-        pic->data[i].r /= 2;
-        pic->data[i].g /= 2;
-        pic->data[i].b /= 2;
-    }
-
-    S_Output_DownloadPicture(pic);
-
-cleanup:
-    if (pic) {
-        Picture_Free(pic);
-        pic = NULL;
-    }
-
-    S_Output_RenderToggle();
 }
 
 void S_Output_CopyFromPicture()

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -766,8 +766,8 @@ void S_Output_DrawSprite(
 }
 
 void S_Output_Draw2DLine(
-    int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGB888 color1,
-    RGB888 color2)
+    int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGBA8888 color1,
+    RGBA8888 color2)
 {
     int vertex_count = 2;
     GFX_3D_Vertex vertices[vertex_count];
@@ -778,6 +778,7 @@ void S_Output_Draw2DLine(
     vertices[0].r = color1.r;
     vertices[0].g = color1.g;
     vertices[0].b = color1.b;
+    vertices[0].a = color1.a;
 
     vertices[1].x = x2;
     vertices[1].y = y2;
@@ -785,16 +786,19 @@ void S_Output_Draw2DLine(
     vertices[1].r = color2.r;
     vertices[1].g = color2.g;
     vertices[1].b = color2.b;
+    vertices[1].a = color2.a;
 
     GFX_3D_Renderer_SetPrimType(m_Renderer3D, GFX_3D_PRIM_LINE);
     S_Output_DisableTextureMode();
+    GFX_3D_Renderer_SetBlendingEnabled(m_Renderer3D, true);
     GFX_3D_Renderer_RenderPrimList(m_Renderer3D, vertices, vertex_count);
+    GFX_3D_Renderer_SetBlendingEnabled(m_Renderer3D, false);
     GFX_3D_Renderer_SetPrimType(m_Renderer3D, GFX_3D_PRIM_TRI);
 }
 
 void S_Output_Draw2DQuad(
-    int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGB888 tl, RGB888 tr,
-    RGB888 bl, RGB888 br)
+    int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGBA8888 tl, RGBA8888 tr,
+    RGBA8888 bl, RGBA8888 br)
 {
     int vertex_count = 4;
     GFX_3D_Vertex vertices[vertex_count];
@@ -805,6 +809,7 @@ void S_Output_Draw2DQuad(
     vertices[0].r = tl.r;
     vertices[0].g = tl.g;
     vertices[0].b = tl.b;
+    vertices[0].a = tl.a;
 
     vertices[1].x = x2;
     vertices[1].y = y1;
@@ -812,6 +817,7 @@ void S_Output_Draw2DQuad(
     vertices[1].r = tr.r;
     vertices[1].g = tr.g;
     vertices[1].b = tr.b;
+    vertices[1].a = tr.a;
 
     vertices[2].x = x2;
     vertices[2].y = y2;
@@ -819,6 +825,7 @@ void S_Output_Draw2DQuad(
     vertices[2].r = br.r;
     vertices[2].g = br.g;
     vertices[2].b = br.b;
+    vertices[2].a = br.a;
 
     vertices[3].x = x1;
     vertices[3].y = y2;
@@ -826,9 +833,12 @@ void S_Output_Draw2DQuad(
     vertices[3].r = bl.r;
     vertices[3].g = bl.g;
     vertices[3].b = bl.b;
+    vertices[3].a = bl.a;
 
     S_Output_DisableTextureMode();
+    GFX_3D_Renderer_SetBlendingEnabled(m_Renderer3D, true);
     S_Output_DrawTriangleStrip(vertices, vertex_count);
+    GFX_3D_Renderer_SetBlendingEnabled(m_Renderer3D, false);
 }
 
 void S_Output_DrawTranslucentQuad(

--- a/src/specific/s_output.h
+++ b/src/specific/s_output.h
@@ -42,11 +42,11 @@ void S_Output_DrawTexturedQuad(
 void S_Output_DrawSprite(
     int16_t x1, int16_t y1, int16_t x2, int y2, int z, int sprnum, int shade);
 void S_Output_Draw2DLine(
-    int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGB888 color1,
-    RGB888 color2);
+    int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGBA8888 color1,
+    RGBA8888 color2);
 void S_Output_Draw2DQuad(
-    int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGB888 tl, RGB888 tr,
-    RGB888 bl, RGB888 br);
+    int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGBA8888 tl, RGBA8888 tr,
+    RGBA8888 bl, RGBA8888 br);
 void S_Output_DrawTranslucentQuad(
     int32_t x1, int32_t y1, int32_t x2, int32_t y2);
 void S_Output_DrawShadow(PHD_VBUF *vbufs, int clip, int vertex_count);

--- a/src/specific/s_output.h
+++ b/src/specific/s_output.h
@@ -13,6 +13,7 @@ void S_Output_RenderBegin();
 void S_Output_RenderEnd();
 void S_Output_RenderToggle();
 void S_Output_DumpScreen();
+void S_Output_ClearDepthBuffer();
 void S_Output_ClearBackBuffer();
 void S_Output_DrawEmpty();
 
@@ -28,7 +29,6 @@ RGB888 S_Output_GetPaletteColor(uint8_t idx);
 void S_Output_DownloadTextures(int32_t pages);
 void S_Output_DownloadPicture(const PICTURE *pic);
 void S_Output_SelectTexture(int tex_num);
-void S_Output_CopyToPicture();
 void S_Output_CopyFromPicture();
 
 void S_Output_DrawFlatTriangle(


### PR DESCRIPTION
This is continuation of #357 and lays the groundwork for the fade-in / fade-out effects. Rather than rendering the hacky picture buffer, we actually render the game, then a translucent quad, then the inventory.

This causes me to drop FPS.
Normally my game runs at around 12 FPS, but the inventory due to its simplicity renders at 25 FPS. With the new approach, the inventory runs at 8 FPS because it has to render both the game and the inventory ring on every frame.

Nonetheless, in my opinion it is acceptable, because I am running the game on a 4k window with a stupid emulator, which is equivalent of having a super potato machine.