### PR TITLE
output: add fade animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Not all options are turned on by default. Refer to `Tomb1Main.json5` for details
 - added support for HD FMVs
 - added fanmade 16:9 menu backgrounds
 - added ability to skip FMVs with the Action key
+- added fade effects
 - changed internal game memory limit from 3.5 MB to 16 MB
 - changed moveable limit from 256 to 10240
 - changed maximum textures from 2048 to 8192

--- a/bin/cfg/Tomb1Main.json5
+++ b/bin/cfg/Tomb1Main.json5
@@ -63,6 +63,10 @@
     // Makes the healthbar and airbar use smooth color transitions.
     "enable_smooth_bars": true,
 
+    // Makes inventory and pause screen use fade transitions for
+    // the semitransparent backdrop, similar to PS1.
+    "enable_fade_effects": true,
+
     // Changes how the healthbar is displayed. Possible values:
     // - default: show the healthbar at the start of a level, after getting
     //   hit, or while having weapons equipped; flash the healthbar if it's already

--- a/src/config.c
+++ b/src/config.c
@@ -137,6 +137,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(enable_compass_stats, true);
     READ_BOOL(enable_timer_in_inventory, true);
     READ_BOOL(enable_smooth_bars, true);
+    READ_BOOL(enable_fade_effects, true);
     READ_BOOL(fix_tihocan_secret_sound, true);
     READ_BOOL(fix_pyramid_secret_trigger, true);
     READ_BOOL(fix_secrets_killing_music, true);

--- a/src/config.h
+++ b/src/config.h
@@ -55,6 +55,7 @@ typedef struct {
     bool enable_compass_stats;
     bool enable_timer_in_inventory;
     bool enable_smooth_bars;
+    bool enable_fade_effects;
     int8_t healthbar_showing_mode;
     int8_t healthbar_location;
     int8_t healthbar_color;

--- a/src/game/control_pause.c
+++ b/src/game/control_pause.c
@@ -97,7 +97,6 @@ static int32_t Control_Pause_Loop()
     while (1) {
         Output_InitialisePolyList();
         Draw_DrawScene(false);
-        Draw_DrawOverlayBackground();
         Control_Pause_DisplayText();
         Text_Draw();
         Output_DumpScreen();
@@ -158,7 +157,9 @@ bool Control_Pause()
     Sound_StopAmbientSounds();
     Sound_StopAllSamples();
 
+    Output_FadeToSemiBlack(true);
     int32_t select = Control_Pause_Loop();
+    Output_FadeToTransparent(true);
 
     Music_Unpause();
     RemoveRequester(&m_PauseRequester);

--- a/src/game/demo.c
+++ b/src/game/demo.c
@@ -76,7 +76,6 @@ int32_t StartDemo()
         Text_Remove(txt);
 
         *s = start;
-        Output_FadeToBlack();
     }
 
     g_Config.enable_enhanced_look = old_enhanced_look;

--- a/src/game/draw.c
+++ b/src/game/draw.c
@@ -1371,6 +1371,7 @@ void Draw_DrawScene(bool draw_overlay)
             PrintRooms(room_num);
         }
     }
+    Output_DrawBackdropScreen();
 }
 
 int32_t Draw_ProcessFrame()
@@ -1380,15 +1381,4 @@ int32_t Draw_ProcessFrame()
     g_Camera.number_frames = Output_DumpScreen();
     Output_AnimateTextures(g_Camera.number_frames);
     return g_Camera.number_frames;
-}
-
-void Draw_DrawOverlayBackground()
-{
-    int32_t sx = 0;
-    int32_t sy = 0;
-    int32_t sw = ViewPort_GetMaxX();
-    int32_t sh = ViewPort_GetMaxY();
-
-    RGBA8888 background = { 0, 0, 0, 128 };
-    Output_DrawScreenFlatQuad(sx, sy, sw, sh, background);
 }

--- a/src/game/draw.h
+++ b/src/game/draw.h
@@ -26,5 +26,4 @@ int16_t *GetBoundsAccurate(ITEM_INFO *item);
 int16_t *GetBestFrame(ITEM_INFO *item);
 
 void Draw_DrawScene(bool draw_overlay);
-void Draw_DrawOverlayBackground();
 int32_t Draw_ProcessFrame();

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -48,7 +48,6 @@ int32_t StopGame()
         return GF_LEVEL_COMPLETE | g_CurrentLevel;
     }
 
-    Output_FadeToBlack();
     if (!g_InvChosen) {
         return GF_EXIT_TO_TITLE;
     }
@@ -170,6 +169,7 @@ void LevelStats(int32_t level_num)
     Text_CentreH(txt, 1);
     Text_CentreV(txt, 1);
 
+    Output_FadeToSemiBlack(true);
     // wait till a skip key is pressed
     do {
         if (g_ResetFlag) {
@@ -177,11 +177,22 @@ void LevelStats(int32_t level_num)
         }
         Output_InitialisePolyList();
         Draw_DrawScene(false);
-        Draw_DrawOverlayBackground();
         Input_Update();
         Text_Draw();
         Output_DumpScreen();
     } while (!g_InputDB.select && !g_InputDB.deselect);
+
+    Output_FadeToBlack(false);
+    Text_RemoveAll();
+
+    // finish fading
+    while (Output_FadeIsAnimating()) {
+        Output_InitialisePolyList();
+        Draw_DrawScene(false);
+        Output_DumpScreen();
+    }
+
+    Output_FadeReset();
 
     if (level_num == g_GameFlow.last_level_num) {
         g_GameInfo.bonus_flag = GBF_NGPLUS;
@@ -191,6 +202,5 @@ void LevelStats(int32_t level_num)
     }
 
     g_GameInfo.start[g_CurrentLevel].flags.available = 0;
-    Output_FadeToBlack();
     Screen_ApplyResolution();
 }

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1081,13 +1081,13 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 
         case GFS_DISPLAY_PICTURE:
             if (level_type != GFL_SAVED) {
+                Output_FadeToTransparent(true);
                 GAMEFLOW_DISPLAY_PICTURE_DATA *data = seq->data;
                 Output_DisplayPicture(data->path);
                 Output_InitialisePolyList();
                 Output_CopyPictureToScreen();
                 Output_DumpScreen();
                 Shell_Wait(data->display_time);
-                Output_FadeToBlack();
             }
             break;
 

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -25,7 +25,15 @@ void Output_SetDrawDistFade(int32_t dist);
 void Output_SetDrawDistMax(int32_t dist);
 void Output_SetWaterColor(const RGBF *color);
 
-void Output_ClearDepth();
+void Output_FadeReset();
+void Output_FadeResetToBlack();
+void Output_FadeToBlack(bool allow_immediate);
+void Output_FadeToSemiBlack(bool allow_immediate);
+void Output_FadeToTransparent(bool allow_immediate);
+bool Output_FadeIsAnimating();
+void Output_DrawBackdropScreen();
+void Output_DrawOverlayScreen();
+
 void Output_ClearScreen();
 void Output_DrawEmpty();
 void Output_InitialisePolyList();
@@ -74,8 +82,6 @@ void Output_DisplayPicture(const char *filename);
 void Output_SetupBelowWater(bool underwater);
 void Output_SetupAboveWater(bool underwater);
 void Output_AnimateTextures(int32_t ticks);
-
-void Output_FadeToBlack();
 
 void Output_ApplyWaterEffect(float *r, float *g, float *b);
 

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -140,8 +140,6 @@ void Shell_Main()
             }
 
             gf_option = Display_Inventory(INV_TITLE_MODE);
-
-            Output_FadeToBlack();
             Music_Stop();
             break;
 

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -246,6 +246,18 @@ void GFX_3D_Renderer_SetSmoothingEnabled(
         &renderer->program, renderer->loc_smoothing_enabled, is_enabled);
 }
 
+void GFX_3D_Renderer_SetDepthTestEnabled(
+    GFX_3D_Renderer *renderer, bool is_enabled)
+{
+    assert(renderer);
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+    if (is_enabled) {
+        glEnable(GL_DEPTH_TEST);
+    } else {
+        glDisable(GL_DEPTH_TEST);
+    }
+}
+
 void GFX_3D_Renderer_SetBlendingEnabled(
     GFX_3D_Renderer *renderer, bool is_enabled)
 {

--- a/src/gfx/3d/3d_renderer.h
+++ b/src/gfx/3d/3d_renderer.h
@@ -49,6 +49,8 @@ void GFX_3D_Renderer_SetPrimType(
     GFX_3D_Renderer *renderer, GFX_3D_PrimType value);
 void GFX_3D_Renderer_SetSmoothingEnabled(
     GFX_3D_Renderer *renderer, bool is_enabled);
+void GFX_3D_Renderer_SetDepthTestEnabled(
+    GFX_3D_Renderer *renderer, bool is_enabled);
 void GFX_3D_Renderer_SetBlendingEnabled(
     GFX_3D_Renderer *renderer, bool is_enabled);
 void GFX_3D_Renderer_SetTexturingEnabled(

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -461,6 +461,16 @@ void S_Output_DisableTextureMode(void)
     GFX_3D_Renderer_SetTexturingEnabled(m_Renderer3D, m_IsTextureMode);
 }
 
+void S_Output_EnableDepthTest(void)
+{
+    GFX_3D_Renderer_SetDepthTestEnabled(m_Renderer3D, true);
+}
+
+void S_Output_DisableDepthTest(void)
+{
+    GFX_3D_Renderer_SetDepthTestEnabled(m_Renderer3D, false);
+}
+
 void S_Output_RenderBegin()
 {
     m_IsRenderingOld = m_IsRendering;
@@ -798,51 +808,6 @@ void S_Output_Draw2DQuad(
     GFX_3D_Renderer_SetBlendingEnabled(m_Renderer3D, false);
 }
 
-void S_Output_DrawTranslucentQuad(
-    int32_t x1, int32_t y1, int32_t x2, int32_t y2)
-{
-    int vertex_count = 4;
-    GFX_3D_Vertex vertices[vertex_count];
-
-    vertices[0].x = x1;
-    vertices[0].y = y1;
-    vertices[0].z = 1.0f;
-    vertices[0].b = 0.0f;
-    vertices[0].g = 0.0f;
-    vertices[0].r = 0.0f;
-    vertices[0].a = 128.0f;
-
-    vertices[1].x = x2;
-    vertices[1].y = y1;
-    vertices[1].z = 1.0f;
-    vertices[1].b = 0.0f;
-    vertices[1].g = 0.0f;
-    vertices[1].r = 0.0f;
-    vertices[1].a = 128.0f;
-
-    vertices[2].x = x2;
-    vertices[2].y = y2;
-    vertices[2].z = 1.0f;
-    vertices[2].b = 0.0f;
-    vertices[2].g = 0.0f;
-    vertices[2].r = 0.0f;
-    vertices[2].a = 128.0f;
-
-    vertices[3].x = x1;
-    vertices[3].y = y2;
-    vertices[3].z = 1.0f;
-    vertices[3].b = 0.0f;
-    vertices[3].g = 0.0f;
-    vertices[3].r = 0.0f;
-    vertices[3].a = 128.0f;
-
-    S_Output_DisableTextureMode();
-
-    GFX_3D_Renderer_SetBlendingEnabled(m_Renderer3D, true);
-    S_Output_DrawTriangleStrip(vertices, vertex_count);
-    GFX_3D_Renderer_SetBlendingEnabled(m_Renderer3D, false);
-}
-
 void S_Output_DrawLightningSegment(
     int x1, int y1, int z1, int thickness1, int x2, int y2, int z2,
     int thickness2)
@@ -963,12 +928,6 @@ void S_Output_DrawShadow(PHD_VBUF *vbufs, int clip, int vertex_count)
     GFX_3D_Renderer_SetBlendingEnabled(m_Renderer3D, true);
     S_Output_DrawTriangleStrip(vertices, vertex_count);
     GFX_3D_Renderer_SetBlendingEnabled(m_Renderer3D, false);
-}
-
-void S_Output_FadeToBlack()
-{
-    S_Output_ClearBackBuffer();
-    S_Output_DumpScreen();
 }
 
 void S_Output_ApplyResolution()

--- a/src/specific/s_output.h
+++ b/src/specific/s_output.h
@@ -8,6 +8,8 @@ void S_Output_Shutdown();
 
 void S_Output_EnableTextureMode(void);
 void S_Output_DisableTextureMode(void);
+void S_Output_EnableDepthTest(void);
+void S_Output_DisableDepthTest(void);
 
 void S_Output_RenderBegin();
 void S_Output_RenderEnd();
@@ -20,8 +22,6 @@ void S_Output_DrawEmpty();
 void S_Output_SetViewport(int width, int height);
 void S_Output_SetFullscreen(bool fullscreen);
 void S_Output_ApplyResolution();
-
-void S_Output_FadeToBlack();
 
 void S_Output_SetPalette(RGB888 palette[256]);
 RGB888 S_Output_GetPaletteColor(uint8_t idx);
@@ -47,8 +47,6 @@ void S_Output_Draw2DLine(
 void S_Output_Draw2DQuad(
     int32_t x1, int32_t y1, int32_t x2, int32_t y2, RGBA8888 tl, RGBA8888 tr,
     RGBA8888 bl, RGBA8888 br);
-void S_Output_DrawTranslucentQuad(
-    int32_t x1, int32_t y1, int32_t x2, int32_t y2);
 void S_Output_DrawShadow(PHD_VBUF *vbufs, int clip, int vertex_count);
 void S_Output_DrawLightningSegment(
     int x1, int y1, int z1, int thickness1, int x2, int y2, int z2,


### PR DESCRIPTION
The fade effects use fixed transparency deltas and thus are FPS dependent. LMK if it's acceptable.

Testing scenarios
- [x] Starting the game. There should be no initial delay before first FMV
- [x] Starting the title screen. It should fade from black. Overlay should be drawn over the ring items.
- [x] Loading a game from the title screen. It should fade to black. Overlay should be drawn over the ring items.
- [x] Starting a demo from the title screen. It should fade to black. Overlay should be drawn over the ring items.
- [x] Starting Gym from the title screen. It should fade to black. Overlay should be drawn over the ring items.
- [x] Starting any level. It should not fade, Lara should be immediately fully visible.
- [x] Finishing a level / stats creen. It should fade to a semitransparent backdrop, then when the player exits the level stats, it should fade to black. Text should be drawn over the backdrop. Text should be completely removed as soon as fade to black happens.
- [x] Pause screen. It should fade to a semitransparent backdrop, then when the player exits the pause screen, it should fade out. Text should be drawn over the backdrop. Text should be completely removed as soon as the player exits the pause screen.
- [x] Opening the inventory. It should open immediately and fade to a semitransparent backdrop in the background.
- [x] Exiting the inventory without doing anything. It should fade to a semitransparent backdrop as soon as the player presses a key.
- [x] Exiting the inventory via using an item. It should use the item immediately and start fading out on the keypress, not after the ring is closed.
- [x] Exiting the inventory via saving the game (entered through Escape). It should start fading out right after choosing the slot, not after the ring is closed.
- [x] Exiting the inventory via saving the game (entered through F5). It should start fading out right after choosing the slot, not after the ring is closed.
- [x] Exiting the inventory via loading the game (entered through Escape). It should fade to black immediately after choosing the slot, not after the ring is closed.
- [x] Exiting the inventory via loading the game (entered through F6). It should fade to black immediately after choosing the slot, not after the ring is closed.
- [x] Exiting the inventory via loading the game (entered through dying). It should fade to black immediately after choosing the slot, not after the ring is closed.
- [x] Exiting the inventory via exiting to title (entered through Escape). It should fade to black immediately after choosing the slot, not after the ring is closed.
- [x] Exiting the inventory via exiting to title (entered through dying). It should fade to black immediately after choosing the slot, not after the ring is closed.
- [x] Exiting the inventory via saving the game in Gym. This redirects the user to starting a new game. It should fade to black immediately after the player confirms.
- [x] Displaying Eidos logo. There should be no fades.
- [x] Displaying credits. There should be no fades. It might be tackled in the future as a separate ticket.
- [x] The version string in the main menu should not be placed above the overlay
- [x] All of these should behave like it used to when the `enable_fade_effects` setting is turned off.
