### PR TITLE
game: fix title menu resuming music after demo when minimized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - fixed broken poses at the end of cinematics (#390)
 - fixed libavcodec-related memory leaks (#389)
 - fixed crash in custom levels that call `level_stats` after playing an FMV (#393, regression from 2.5)
-
+- fixed sounds playing after demo mode ends when game is minimized (#399)
 
 ## [2.5](https://github.com/rr-/Tomb1Main/compare/2.4...2.5) - 2022-01-31
 - added CHANGELOG.md

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -94,7 +94,6 @@ int32_t GameLoop(GAMEFLOW_LEVEL_TYPE level_type)
 
     Sound_StopAllSamples();
     Music_Stop();
-    Music_SetVolume(g_Config.music_volume);
 
     if (ret == GF_NOP_BREAK) {
         return GF_NOP;


### PR DESCRIPTION
Resolves #399.

I tested things like minimizing for multiple demos, credits, pause screens, etc and didn't notice any bugs with this solution.