### PR TITLE
ai/pod: spawn only objects that are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed libavcodec-related memory leaks (#389)
 - fixed crash in custom levels that call `level_stats` after playing an FMV (#393, regression from 2.5)
 - fixed sounds playing after demo mode ends when game is minimized (#399)
+- fixed empty mutant shells in Unfinished Business spawning Lara's hips (#250)
 
 ## [2.5](https://github.com/rr-/Tomb1Main/compare/2.4...2.5) - 2022-01-31
 - added CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Not all options are turned on by default. Refer to `Tomb1Main.json5` for details
 - fixed game audio not muting when game is minimized
 - fixed Lara switching to pistols when completing a level with other guns
 - fixed detail levels text flashing with any option change
+- fixed empty mutant shells in Unfinished Business spawning Lara's hips
 
 ## Showcase
 

--- a/src/game/ai/pod.c
+++ b/src/game/ai/pod.c
@@ -108,12 +108,14 @@ void PodControl(int16_t item_num)
 
             int16_t bug_item_num = *(int16_t *)item->data;
             ITEM_INFO *bug = &g_Items[bug_item_num];
-            bug->touch_bits = 0;
-            AddActiveItem(bug_item_num);
-            if (EnableBaddieAI(bug_item_num, 0)) {
-                bug->status = IS_ACTIVE;
-            } else {
-                bug->status = IS_INVISIBLE;
+            if (g_Objects[bug->object_number].loaded) {
+                bug->touch_bits = 0;
+                AddActiveItem(bug_item_num);
+                if (EnableBaddieAI(bug_item_num, 0)) {
+                    bug->status = IS_ACTIVE;
+                } else {
+                    bug->status = IS_INVISIBLE;
+                }
             }
         }
     }


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes

#### Descripton

Fixes #250.
This makes empty pods no longer spawn Lara's hips. This is consistent with Stella's walkthrough, that clearly states that these shells are supposed to be "duds". This doesn't break savegames.