### PR TITLE
Move Lara's initial hitpoints to STARTINFO

### DIFF
--- a/src/game/control.c
+++ b/src/game/control.c
@@ -312,19 +312,6 @@ int32_t ControlPhase(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
         g_GameInfo.timer++;
         Overlay_BarHealthTimerTick();
 
-        if (g_Config.disable_healing_between_levels) {
-            int8_t lara_found = 0;
-            for (int i = 0; i < g_LevelItemCount; i++) {
-                if (g_Items[i].object_number == O_LARA) {
-                    lara_found = 1;
-                }
-            }
-            if (lara_found) {
-                g_StoredLaraHealth =
-                    g_LaraItem ? g_LaraItem->hit_points : LARA_HITPOINTS;
-            }
-        }
-
         m_FrameCount -= 0x10000;
     }
 

--- a/src/game/laramisc.c
+++ b/src/game/laramisc.c
@@ -432,17 +432,20 @@ void ControlLaraExtra(int16_t item_num)
 void InitialiseLaraLoad(int16_t item_num)
 {
     g_Lara.item_number = item_num;
-    g_LaraItem = &g_Items[item_num];
+    if (item_num == NO_ITEM) {
+        g_LaraItem = NULL;
+    } else {
+        g_LaraItem = &g_Items[item_num];
+    }
 }
 
 void InitialiseLara()
 {
+    START_INFO *start = &g_GameInfo.start[g_CurrentLevel];
+
     g_LaraItem->collidable = 0;
     g_LaraItem->data = &g_Lara;
-    g_LaraItem->hit_points = LARA_HITPOINTS;
-    if (g_Config.disable_healing_between_levels) {
-        g_LaraItem->hit_points = g_StoredLaraHealth;
-    }
+    g_LaraItem->hit_points = start->lara_hitpoints;
 
     g_Lara.air = LARA_AIR;
     g_Lara.torso_y_rot = 0;

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -60,6 +60,7 @@ static bool Level_LoadFromFile(const char *filename, int32_t level_num)
 
     GameBuf_Shutdown();
     GameBuf_Init();
+
     MYFILE *fp = File_Open(filename, FILE_OPEN_READ);
     if (!fp) {
         Shell_ExitSystemFmt(
@@ -652,27 +653,6 @@ bool Level_Load(int level_num)
              ? g_GameFlow.levels[level_num].draw_distance_max.value
              : g_GameFlow.draw_distance_max)
         * WALL_L);
-
-    if (g_Config.disable_healing_between_levels) {
-        // check if we're in main menu by seeing if there is g_Lara item in the
-        // currently loaded level.
-        bool lara_found = false;
-        bool in_cutscene = false;
-        for (int i = 0; i < g_LevelItemCount; i++) {
-            if (g_Items[i].object_number == O_LARA) {
-                lara_found = true;
-            }
-            if (g_Items[i].object_number == O_PLAYER_1
-                || g_Items[i].object_number == O_PLAYER_2
-                || g_Items[i].object_number == O_PLAYER_3
-                || g_Items[i].object_number == O_PLAYER_4) {
-                in_cutscene = true;
-            }
-        }
-        if (!lara_found && !in_cutscene) {
-            g_StoredLaraHealth = LARA_HITPOINTS;
-        }
-    }
 
     return ret;
 }

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -1,5 +1,6 @@
 #include "game/savegame.h"
 
+#include "config.h"
 #include "filesystem.h"
 #include "game/ai/pod.h"
 #include "game/control.h"
@@ -192,6 +193,12 @@ void ModifyStartInfo(int32_t level_num)
 
     START_INFO *start = &g_GameInfo.start[level_num];
 
+    if (!g_Config.disable_healing_between_levels
+        || level_num == g_GameFlow.gym_level_num
+        || level_num == g_GameFlow.first_level_num) {
+        start->lara_hitpoints = LARA_HITPOINTS;
+    }
+
     if (level_num == g_GameFlow.gym_level_num) {
         start->flags.available = 1;
         start->flags.costume = 1;
@@ -247,6 +254,20 @@ void CreateStartInfo(int level_num)
     // Used to carry over Lara's inventory between levels.
 
     START_INFO *start = &g_GameInfo.start[level_num];
+
+    if (g_LaraItem) {
+        start->lara_hitpoints = g_LaraItem->hit_points;
+    } else {
+        // Carry over variables from previous levels if the current level
+        // has no Lara object (such as the cutscene levels)
+        for (int l = level_num - 1; l >= 0; l--) {
+            START_INFO *prev_start = &g_GameInfo.start[l];
+            if (g_GameFlow.levels[l].level_type == GFL_NORMAL) {
+                start->lara_hitpoints = prev_start->lara_hitpoints;
+                break;
+            }
+        }
+    }
 
     start->flags.available = 1;
     start->flags.costume = 0;

--- a/src/game/savegame_bson.c
+++ b/src/game/savegame_bson.c
@@ -143,6 +143,8 @@ static bool SaveGame_BSON_LoadLevels(
             return false;
         }
         START_INFO *start = &game_info->start[i];
+        start->lara_hitpoints =
+            json_object_get_int(level_obj, "lara_hitpoints", LARA_HITPOINTS);
         start->pistol_ammo = json_object_get_int(level_obj, "pistol_ammo", 0);
         start->magnum_ammo = json_object_get_int(level_obj, "magnum_ammo", 0);
         start->uzi_ammo = json_object_get_int(level_obj, "uzi_ammo", 0);
@@ -571,6 +573,8 @@ static struct json_array_s *SaveGame_BSON_DumpLevels(GAME_INFO *game_info)
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         START_INFO *start = &game_info->start[i];
         struct json_object_s *level_obj = json_object_new();
+        json_object_append_int(
+            level_obj, "lara_hitpoints", start->lara_hitpoints);
         json_object_append_int(level_obj, "pistol_ammo", start->pistol_ammo);
         json_object_append_int(level_obj, "magnum_ammo", start->magnum_ammo);
         json_object_append_int(level_obj, "uzi_ammo", start->uzi_ammo);

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -96,7 +96,7 @@ bool InitialiseLevel(int32_t level_num)
     Text_RemoveAll();
     InitialiseGameFlags();
 
-    g_Lara.item_number = NO_ITEM;
+    InitialiseLaraLoad(NO_ITEM);
     if (level_num != g_GameFlow.title_level_num) {
         Screen_ApplyResolution();
     }

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1448,6 +1448,7 @@ typedef struct LARA_INFO {
 } LARA_INFO;
 
 typedef struct START_INFO {
+    int32_t lara_hitpoints;
     uint16_t pistol_ammo;
     uint16_t magnum_ammo;
     uint16_t uzi_ammo;


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] ~~I have added a changelog entry about what my pull request accomplishes~~
    This is an internal refactor without value to the end user.

#### Descripton

Resolves #212 

#### Testing

- [x] (Healing between levels disabled) Starting new game from scratch, Lara should have full HP
- [x] (Healing between levels disabled) Starting Gym from scratch, Lara should have full HP
- [x] (Healing between levels disabled) Starting new game after exiting to title from a save where Lara had less than 100% HP
- [x] (Healing between levels disabled) Starting Gym after exiting to title from a save where Lara had less than 100% HP
- [x] (Healing between levels disabled) Advancing to the next level
- [x] (Healing between levels disabled) Advancing to the next level beyond a cutscene-type level
- [x] (Healing between levels disabled) Loading saved game
- [x] (Healing between levels disabled) Loading saved game and then advancing to the next level
- [x] (Healing between levels enabled) Starting new game from scratch, Lara should have full HP
- [x] (Healing between levels enabled) Starting Gym from scratch, Lara should have full HP
- [x] (Healing between levels enabled) Starting new game after exiting to title from a save where Lara had less than 100% HP
- [x] (Healing between levels enabled) Starting Gym after exiting to title from a save where Lara had less than 100% HP
- [x] (Healing between levels enabled) Advancing to the next level
- [x] (Healing between levels enabled) Advancing to the next level beyond a cutscene-type level
- [x] (Healing between levels enabled) Loading saved game
- [x] (Healing between levels enabled) Loading saved game and then advancing to the next level