### PR TITLE
Save level stats separately for each level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed broken poses at the end of cinematics (#390)
 - fixed libavcodec-related memory leaks (#389)
 - fixed crash in custom levels that call `level_stats` after playing an FMV (#393, regression from 2.5)
+- fixed calling `level_stats` for different levels (#336, requires new saves)
 - fixed sounds playing after demo mode ends when game is minimized (#399)
 - fixed glitched floor in the Natla cutscene
 - fixed gun pickups disappearing in rare circumstances on save load (#406)

--- a/src/game/control.c
+++ b/src/game/control.c
@@ -305,7 +305,7 @@ int32_t ControlPhase(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
 
         CalculateCamera();
         Sound_UpdateEffects();
-        g_GameInfo.timer++;
+        g_GameInfo.stats.timer++;
         Overlay_BarHealthTimerTick();
 
         m_FrameCount -= 0x10000;
@@ -727,10 +727,10 @@ void TestTriggers(int16_t *data, int32_t heavy)
             break;
 
         case TO_SECRET:
-            if ((g_GameInfo.secrets & (1 << value))) {
+            if ((g_GameInfo.stats.secret_flags & (1 << value))) {
                 break;
             }
-            g_GameInfo.secrets |= 1 << value;
+            g_GameInfo.stats.secret_flags |= 1 << value;
             Music_Play(13);
             break;
         }

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -27,7 +27,7 @@ bool StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
     if (level_type == GFL_SAVED) {
         // reset start info to the defaults so that we do not do
         // GlobalItemReplace in the inventory initialization routines too early
-        ResetStartInfo(level_num);
+        Savegame_ResetStartInfo(level_num);
     } else {
         InitialiseLevelFlags();
     }
@@ -37,7 +37,7 @@ bool StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
     }
 
     if (level_type == GFL_SAVED) {
-        if (!SaveGame_Load(g_GameInfo.save_slot_to_load, &g_GameInfo)) {
+        if (!Savegame_Load(g_GameInfo.save_slot_to_load, &g_GameInfo)) {
             LOG_ERROR("Failed to load save file!");
             return false;
         }
@@ -48,13 +48,13 @@ bool StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 
 int32_t StopGame()
 {
-    CreateEndInfo(g_CurrentLevel);
+    Savegame_PersistGameToEndInfo(g_CurrentLevel);
 
     if (g_CurrentLevel == g_GameFlow.last_level_num) {
         g_GameInfo.bonus_flag = GBF_NGPLUS;
     } else {
-        CreateStartInfo(g_CurrentLevel + 1);
-        ModifyStartInfo(g_CurrentLevel + 1);
+        Savegame_PersistGameToStartInfo(g_CurrentLevel + 1);
+        Savegame_ApplyLogicToStartInfo(g_CurrentLevel + 1);
     }
 
     g_GameInfo.start[g_CurrentLevel].flags.available = 0;
@@ -103,7 +103,7 @@ int32_t GameLoop(GAMEFLOW_LEVEL_TYPE level_type)
         if (ask_for_save) {
             int32_t return_val = Display_Inventory(INV_SAVE_CRYSTAL_MODE);
             if (return_val != GF_NOP) {
-                SaveGame_Save(g_InvExtraData[1], &g_GameInfo);
+                Savegame_Save(g_InvExtraData[1], &g_GameInfo);
                 Settings_Write();
             }
             ask_for_save = false;
@@ -118,9 +118,4 @@ int32_t GameLoop(GAMEFLOW_LEVEL_TYPE level_type)
     }
 
     return ret;
-}
-
-int32_t LevelCompleteSequence(int32_t level_num)
-{
-    return GF_EXIT_TO_TITLE;
 }

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -48,6 +48,17 @@ bool StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 
 int32_t StopGame()
 {
+    CreateEndInfo(g_CurrentLevel);
+
+    if (g_CurrentLevel == g_GameFlow.last_level_num) {
+        g_GameInfo.bonus_flag = GBF_NGPLUS;
+    } else {
+        CreateStartInfo(g_CurrentLevel + 1);
+        ModifyStartInfo(g_CurrentLevel + 1);
+    }
+
+    g_GameInfo.start[g_CurrentLevel].flags.available = 0;
+
     if (g_LevelComplete) {
         return GF_LEVEL_COMPLETE | g_CurrentLevel;
     }
@@ -71,9 +82,9 @@ int32_t GameLoop(GAMEFLOW_LEVEL_TYPE level_type)
     InitialiseCamera();
 
     Stats_CalculateStats();
-    g_GameFlow.levels[g_CurrentLevel].pickups = Stats_GetPickups();
-    g_GameFlow.levels[g_CurrentLevel].kills = Stats_GetKillables();
-    g_GameFlow.levels[g_CurrentLevel].secrets = Stats_GetSecrets();
+    g_GameInfo.stats.max_pickup_count = Stats_GetPickups();
+    g_GameInfo.stats.max_kill_count = Stats_GetKillables();
+    g_GameInfo.stats.max_secret_count = Stats_GetSecrets();
 
     bool ask_for_save = g_GameFlow.enable_save_crystals
         && level_type == GFL_NORMAL

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -7,5 +7,3 @@
 bool StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
 int32_t StopGame();
 int32_t GameLoop(GAMEFLOW_LEVEL_TYPE level_type);
-int32_t LevelCompleteSequence(int32_t level_num);
-void LevelStats(int32_t level_num);

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -552,6 +552,7 @@ static bool GameFlow_LoadScriptLevels(struct json_object_s *obj)
 
     g_GameFlow.levels = Memory_Alloc(sizeof(GAMEFLOW_LEVEL) * level_count);
     g_GameInfo.start = Memory_Alloc(sizeof(START_INFO) * level_count);
+    g_GameInfo.end = Memory_Alloc(sizeof(END_INFO) * level_count);
 
     struct json_array_element_s *jlvl_elem = jlvl_arr->start;
     int level_num = 0;
@@ -829,6 +830,7 @@ void GameFlow_Shutdown()
     Memory_FreePointer(&g_GameFlow.savegame_fmt_legacy);
     Memory_FreePointer(&g_GameFlow.savegame_fmt_bson);
     Memory_FreePointer(&g_GameInfo.start);
+    Memory_FreePointer(&g_GameInfo.end);
 
     for (int i = 0; i < GS_NUMBER_OF; i++) {
         Memory_FreePointer(&g_GameFlow.strings[i]);

--- a/src/game/gameflow.h
+++ b/src/game/gameflow.h
@@ -30,9 +30,6 @@ typedef struct GAMEFLOW_LEVEL {
     char *puzzle3;
     char *puzzle4;
     int8_t demo;
-    int16_t secrets;
-    int16_t pickups;
-    int16_t kills;
     GAMEFLOW_SEQUENCE *sequence;
     struct {
         bool override;

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -270,7 +270,7 @@ int32_t Display_Inventory(int inv_mode)
         g_Camera.number_frames = m_InvNFrames;
 
         if (g_Config.enable_timer_in_inventory) {
-            g_GameInfo.timer += m_InvNFrames / 2;
+            g_GameInfo.stats.timer += m_InvNFrames / 2;
         }
 
         if (ring.rotating) {

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -691,7 +691,7 @@ int32_t Display_Inventory(int inv_mode)
                     g_GameInfo.bonus_flag = GBF_JAPANESE | GBF_NGPLUS;
                     break;
                 }
-                InitialiseStartInfo();
+                Savegame_InitStartEndInfo();
                 return GF_START_GAME | g_GameFlow.first_level_num;
             } else {
                 // page 3: exit game
@@ -718,10 +718,10 @@ int32_t Display_Inventory(int inv_mode)
                         g_GameInfo.bonus_flag = GBF_JAPANESE | GBF_NGPLUS;
                         break;
                     }
-                    InitialiseStartInfo();
+                    Savegame_InitStartEndInfo();
                     return GF_START_GAME | g_GameFlow.first_level_num;
                 } else {
-                    SaveGame_Save(g_InvExtraData[1], &g_GameInfo);
+                    Savegame_Save(g_InvExtraData[1], &g_GameInfo);
                     Settings_Write();
                     return GF_NOP;
                 }

--- a/src/game/larafire.c
+++ b/src/game/larafire.c
@@ -600,7 +600,7 @@ int32_t FireWeapon(
 void HitTarget(ITEM_INFO *item, GAME_VECTOR *hitpos, int32_t damage)
 {
     if (item->hit_points > 0 && item->hit_points <= damage) {
-        g_GameInfo.kills++;
+        g_GameInfo.stats.kill_count++;
     }
     item->hit_points -= damage;
     item->hit_status = 1;

--- a/src/game/objects/pickup.c
+++ b/src/game/objects/pickup.c
@@ -64,7 +64,7 @@ void PickUpCollision(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
             Inv_AddItem(item->object_number);
             item->status = IS_INVISIBLE;
             RemoveDrawnItem(item_num);
-            g_GameInfo.pickups++;
+            g_GameInfo.stats.pickup_count++;
             return;
         }
 
@@ -91,7 +91,7 @@ void PickUpCollision(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
             Inv_AddItem(item->object_number);
             item->status = IS_INVISIBLE;
             RemoveDrawnItem(item_num);
-            g_GameInfo.pickups++;
+            g_GameInfo.stats.pickup_count++;
             return;
         }
 

--- a/src/game/objects/savegame_crystal.c
+++ b/src/game/objects/savegame_crystal.c
@@ -12,17 +12,17 @@
 #include "game/sound.h"
 #include "global/vars.h"
 
-void SetupSaveGameCrystal(OBJECT_INFO *obj)
+void SetupSavegameCrystal(OBJECT_INFO *obj)
 {
-    obj->initialise = InitialiseSaveGameItem;
+    obj->initialise = InitialiseSavegameItem;
     if (g_GameFlow.enable_save_crystals) {
-        obj->control = ControlSaveGameItem;
-        obj->collision = PickUpSaveGameCollision;
+        obj->control = ControlSavegameItem;
+        obj->collision = PickUpSavegameCollision;
         obj->save_flags = 1;
     }
 }
 
-void InitialiseSaveGameItem(int16_t item_num)
+void InitialiseSavegameItem(int16_t item_num)
 {
     if (g_GameFlow.enable_save_crystals) {
         AddActiveItem(item_num);
@@ -31,14 +31,14 @@ void InitialiseSaveGameItem(int16_t item_num)
     }
 }
 
-void ControlSaveGameItem(int16_t item_num)
+void ControlSavegameItem(int16_t item_num)
 {
     if (g_GameFlow.enable_save_crystals) {
         AnimateItem(&g_Items[item_num]);
     }
 }
 
-void PickUpSaveGameCollision(
+void PickUpSavegameCollision(
     int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
 {
     ITEM_INFO *item = &g_Items[item_num];
@@ -63,7 +63,7 @@ void PickUpSaveGameCollision(
     if (return_val != GF_NOP) {
         item->status = IS_INVISIBLE;
         RemoveDrawnItem(item_num);
-        SaveGame_Save(g_InvExtraData[1], &g_GameInfo);
+        Savegame_Save(g_InvExtraData[1], &g_GameInfo);
         Settings_Write();
         Sound_Effect(SFX_LARA_OBJECT, NULL, SPM_ALWAYS);
     } else {

--- a/src/game/objects/savegame_crystal.h
+++ b/src/game/objects/savegame_crystal.h
@@ -4,8 +4,8 @@
 
 #include <stdint.h>
 
-void SetupSaveGameCrystal(OBJECT_INFO *obj);
-void InitialiseSaveGameItem(int16_t item_num);
-void ControlSaveGameItem(int16_t item_num);
-void PickUpSaveGameCollision(
+void SetupSavegameCrystal(OBJECT_INFO *obj);
+void InitialiseSavegameItem(int16_t item_num);
+void ControlSavegameItem(int16_t item_num);
+void PickUpSavegameCollision(
     int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll);

--- a/src/game/objects/scion.c
+++ b/src/game/objects/scion.c
@@ -149,7 +149,7 @@ void PickUpScionCollision(
             Inv_AddItem(item->object_number);
             item->status = IS_INVISIBLE;
             RemoveDrawnItem(item_num);
-            g_GameInfo.pickups++;
+            g_GameInfo.stats.pickup_count++;
         }
     } else if (
         g_Input.action && g_Lara.gun_status == LGS_ARMLESS

--- a/src/game/option_compass.c
+++ b/src/game/option_compass.c
@@ -40,31 +40,31 @@ static void Option_CompassInitText()
     m_Text[TEXT_TIME] = Text_Create(0, y, " ");
     y += ROW_HEIGHT;
 
-    int32_t secrets_taken = 0;
-    int32_t secrets_total = MAX_SECRETS;
-    int32_t secrets_flags = g_GameInfo.secrets;
-    do {
-        if (secrets_flags & 1) {
-            secrets_taken++;
+    const GAME_STATS *stats = &g_GameInfo.stats;
+
+    int32_t secret_count = 0;
+    int32_t secret_flags = stats->secret_flags;
+    for (int i = 0; i < MAX_SECRETS; i++) {
+        if (secret_flags & 1) {
+            secret_count++;
         }
-        secrets_flags >>= 1;
-        secrets_total--;
-    } while (secrets_total);
+        secret_flags >>= 1;
+    }
     sprintf(
-        buf, g_GameFlow.strings[GS_STATS_SECRETS_FMT], secrets_taken,
-        g_GameFlow.levels[g_CurrentLevel].secrets);
+        buf, g_GameFlow.strings[GS_STATS_SECRETS_FMT], secret_count,
+        g_GameInfo.stats.max_secret_count);
     m_Text[TEXT_SECRETS] = Text_Create(0, y, buf);
     y += ROW_HEIGHT;
 
     sprintf(
-        buf, g_GameFlow.strings[GS_STATS_PICKUPS_FMT], g_GameInfo.pickups,
-        g_GameFlow.levels[g_CurrentLevel].pickups);
+        buf, g_GameFlow.strings[GS_STATS_PICKUPS_FMT], stats->pickup_count,
+        stats->max_pickup_count);
     m_Text[TEXT_PICKUPS] = Text_Create(0, y, buf);
     y += ROW_HEIGHT;
 
     sprintf(
-        buf, g_GameFlow.strings[GS_STATS_KILLS_FMT], g_GameInfo.kills,
-        g_GameFlow.levels[g_CurrentLevel].kills);
+        buf, g_GameFlow.strings[GS_STATS_KILLS_FMT], stats->kill_count,
+        stats->max_kill_count);
     m_Text[TEXT_KILLS] = Text_Create(0, y, buf);
     y += ROW_HEIGHT;
 
@@ -89,7 +89,7 @@ void Option_Compass(INVENTORY_ITEM *inv_item)
             Option_CompassInitText();
         }
 
-        int32_t seconds = g_GameInfo.timer / 30;
+        int32_t seconds = g_GameInfo.stats.timer / 30;
         int32_t hours = seconds / 3600;
         int32_t minutes = (seconds / 60) % 60;
         seconds %= 60;

--- a/src/game/option_passport.c
+++ b/src/game/option_passport.c
@@ -36,10 +36,10 @@ static REQUEST_INFO m_NewGameRequester = {
     0,
 };
 
-static char m_LoadSaveGameStrings[MAX_SAVE_SLOTS][MAX_LEVEL_NAME_LENGTH] = {
+static char m_LoadSavegameStrings[MAX_SAVE_SLOTS][MAX_LEVEL_NAME_LENGTH] = {
     0
 };
-REQUEST_INFO g_LoadSaveGameRequester = {
+REQUEST_INFO g_LoadSavegameRequester = {
     .items = 1,
     .requested = 0,
     .vis_lines = -1,
@@ -52,7 +52,7 @@ REQUEST_INFO g_LoadSaveGameRequester = {
     .z = 0,
     .flags = 0,
     .heading_text = NULL,
-    .item_texts = &m_LoadSaveGameStrings[0][0],
+    .item_texts = &m_LoadSavegameStrings[0][0],
     .item_text_len = MAX_LEVEL_NAME_LENGTH,
     0,
 };
@@ -72,9 +72,9 @@ static void InitNewGameRequester()
     req->vis_lines = MAX_GAME_MODES;
 }
 
-static void InitLoadSaveGameRequester()
+static void InitLoadSavegameRequester()
 {
-    REQUEST_INFO *req = &g_LoadSaveGameRequester;
+    REQUEST_INFO *req = &g_LoadSavegameRequester;
     InitRequester(req);
     SetRequesterHeading(req, g_GameFlow.strings[GS_PASSPORT_SELECT_LEVEL]);
 
@@ -107,7 +107,7 @@ static void InitLoadSaveGameRequester()
         req->vis_lines = 12;
     }
 
-    SaveGame_ScanSavedGames();
+    Savegame_ScanSavedGames();
 }
 
 void Option_Passport(INVENTORY_ITEM *inv_item)
@@ -129,7 +129,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
     switch (page) {
     case 0:
         if (m_PassportMode == 1) {
-            int32_t select = DisplayRequester(&g_LoadSaveGameRequester);
+            int32_t select = DisplayRequester(&g_LoadSavegameRequester);
             if (select) {
                 if (select > 0) {
                     g_InvExtraData[1] = select - 1;
@@ -162,8 +162,8 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                     Text_Remove(g_InvItemText[IT_NAME]);
                     g_InvItemText[IT_NAME] = NULL;
 
-                    g_LoadSaveGameRequester.flags |= RIF_BLOCKABLE;
-                    InitLoadSaveGameRequester();
+                    g_LoadSavegameRequester.flags |= RIF_BLOCKABLE;
+                    InitLoadSavegameRequester();
                     m_PassportMode = 1;
                     g_Input = (INPUT_STATE) { 0 };
                     g_InputDB = (INPUT_STATE) { 0 };
@@ -188,7 +188,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                 g_InputDB = (INPUT_STATE) { 0 };
             }
         } else if (m_PassportMode == 1) {
-            int32_t select = DisplayRequester(&g_LoadSaveGameRequester);
+            int32_t select = DisplayRequester(&g_LoadSavegameRequester);
             if (select) {
                 if (select > 0) {
                     m_PassportMode = 0;
@@ -249,8 +249,8 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                     Text_Remove(g_InvItemText[IT_NAME]);
                     g_InvItemText[IT_NAME] = NULL;
 
-                    g_LoadSaveGameRequester.flags &= ~RIF_BLOCKABLE;
-                    InitLoadSaveGameRequester();
+                    g_LoadSavegameRequester.flags &= ~RIF_BLOCKABLE;
+                    InitLoadSavegameRequester();
                     m_PassportMode = 1;
                     g_Input = (INPUT_STATE) { 0 };
                     g_InputDB = (INPUT_STATE) { 0 };

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -441,8 +441,8 @@ void Overlay_DrawAmmoInfo()
 void Overlay_DrawPickups()
 {
     static int32_t old_game_timer = 0;
-    int16_t time = g_GameInfo.timer - old_game_timer;
-    old_game_timer = g_GameInfo.timer;
+    int16_t time = g_GameInfo.stats.timer - old_game_timer;
+    old_game_timer = g_GameInfo.stats.timer;
 
     if (time > 0 && time < 60) {
         int32_t sprite_height =

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -172,13 +172,14 @@ void InitialiseStartInfo()
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         ResetStartInfo(i);
         ModifyStartInfo(i);
+        ResetEndInfo(i);
         g_GameInfo.start[i].flags.available = 0;
     }
     g_GameInfo.start[g_GameFlow.gym_level_num].flags.available = 1;
     g_GameInfo.start[g_GameFlow.first_level_num].flags.available = 1;
 }
 
-void ResetStartInfo(int32_t level_num)
+void ResetStartInfo(int level_num)
 {
     // Reset the start info to blank state.
 
@@ -187,7 +188,7 @@ void ResetStartInfo(int32_t level_num)
     ModifyStartInfo(level_num);
 }
 
-void ModifyStartInfo(int32_t level_num)
+void ModifyStartInfo(int level_num)
 {
     // Apply game mechanics to the start info.
 
@@ -316,6 +317,18 @@ void CreateStartInfo(int level_num)
     }
 }
 
+void ResetEndInfo(int level_num)
+{
+    END_INFO *end = &g_GameInfo.end[level_num];
+    memset(end, 0, sizeof(END_INFO));
+}
+
+void CreateEndInfo(int level_num)
+{
+    END_INFO *end = &g_GameInfo.end[level_num];
+    end->stats = g_GameInfo.stats;
+}
+
 int32_t SaveGame_GetLevelNumber(int32_t slot_num)
 {
     return m_SaveGameInfo[slot_num].level_num;
@@ -358,6 +371,7 @@ bool SaveGame_Save(int32_t slot_num, GAME_INFO *game_info)
     File_CreateDirectory(SAVES_DIR);
 
     CreateStartInfo(g_CurrentLevel);
+    CreateEndInfo(g_CurrentLevel);
 
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         if (g_GameFlow.levels[i].level_type == GFL_CURRENT) {

--- a/src/game/savegame.h
+++ b/src/game/savegame.h
@@ -12,10 +12,9 @@
 // creatures, triggers etc., and is what actually sets Lara's health, creatures
 // status, triggers, inventory etc.
 
+#include "game/savegame_common.h"
+
 void InitialiseStartInfo();
-void ResetStartInfo(int32_t level_num);
-void CreateStartInfo(int level_num);
-void ModifyStartInfo(int32_t level_num);
 
 int32_t SaveGame_GetLevelNumber(int32_t slot_num);
 

--- a/src/game/savegame.h
+++ b/src/game/savegame.h
@@ -14,12 +14,12 @@
 
 #include "game/savegame_common.h"
 
-void InitialiseStartInfo();
+void Savegame_InitStartEndInfo();
 
-int32_t SaveGame_GetLevelNumber(int32_t slot_num);
+int32_t Savegame_GetLevelNumber(int32_t slot_num);
 
-bool SaveGame_Load(int32_t slot_num, GAME_INFO *game_info);
-bool SaveGame_Save(int32_t slot_num, GAME_INFO *game_info);
+bool Savegame_Load(int32_t slot_num, GAME_INFO *game_info);
+bool Savegame_Save(int32_t slot_num, GAME_INFO *game_info);
 
-void SaveGame_ScanSavedGames();
-void SaveGame_Shutdown();
+void Savegame_ScanSavedGames();
+void Savegame_Shutdown();

--- a/src/game/savegame_bson.c
+++ b/src/game/savegame_bson.c
@@ -31,38 +31,38 @@ typedef struct SAVEGAME_BSON_HEADER {
     int32_t uncompressed_size;
 } SAVEGAME_BSON_HEADER;
 
-static bool SaveGame_BSON_IsValidItemObject(
+static bool Savegame_BSON_IsValidItemObject(
     int16_t saved_obj_num, int16_t current_obj_num);
-static struct json_value_s *SaveGame_BSON_ParseFromFile(MYFILE *fp);
-static bool SaveGame_BSON_LoadStartInfo(
+static struct json_value_s *Savegame_BSON_ParseFromFile(MYFILE *fp);
+static bool Savegame_BSON_LoadStartInfo(
     struct json_array_s *levels_arr, GAME_INFO *game_info);
-static bool SaveGame_BSON_LoadEndInfo(
+static bool Savegame_BSON_LoadEndInfo(
     struct json_array_s *levels_arr, GAME_INFO *game_info);
-static bool SaveGame_BSON_LoadMisc(
+static bool Savegame_BSON_LoadMisc(
     struct json_object_s *misc_obj, GAME_INFO *game_info);
-static bool SaveGame_BSON_LoadInventory(struct json_object_s *inv_obj);
-static bool SaveGame_BSON_LoadFlipmaps(struct json_object_s *flipmap_obj);
-static bool SaveGame_BSON_LoadCameras(struct json_array_s *cameras_arr);
-static bool SaveGame_BSON_LoadItems(struct json_array_s *items_arr);
-static bool SaveGame_BSON_LoadArm(struct json_object_s *arm_obj, LARA_ARM *arm);
-static bool SaveGame_BSON_LoadAmmo(
+static bool Savegame_BSON_LoadInventory(struct json_object_s *inv_obj);
+static bool Savegame_BSON_LoadFlipmaps(struct json_object_s *flipmap_obj);
+static bool Savegame_BSON_LoadCameras(struct json_array_s *cameras_arr);
+static bool Savegame_BSON_LoadItems(struct json_array_s *items_arr);
+static bool Savegame_BSON_LoadArm(struct json_object_s *arm_obj, LARA_ARM *arm);
+static bool Savegame_BSON_LoadAmmo(
     struct json_object_s *ammo_obj, AMMO_INFO *ammo);
-static bool SaveGame_BSON_LoadLOT(struct json_object_s *lot_obj, LOT_INFO *lot);
-static bool SaveGame_BSON_LoadLara(
+static bool Savegame_BSON_LoadLOT(struct json_object_s *lot_obj, LOT_INFO *lot);
+static bool Savegame_BSON_LoadLara(
     struct json_object_s *lara_obj, LARA_INFO *lara);
-static struct json_array_s *SaveGame_BSON_DumpStartInfo(GAME_INFO *game_info);
-static struct json_array_s *SaveGame_BSON_DumpEndInfo(GAME_INFO *game_info);
-static struct json_object_s *SaveGame_BSON_DumpMisc(GAME_INFO *game_info);
-static struct json_object_s *SaveGame_BSON_DumpInventory();
-static struct json_object_s *SaveGame_BSON_DumpFlipmaps();
-static struct json_array_s *SaveGame_BSON_DumpCameras();
-static struct json_array_s *SaveGame_BSON_DumpItems();
-static struct json_object_s *SaveGame_BSON_DumpArm(LARA_ARM *arm);
-static struct json_object_s *SaveGame_BSON_DumpAmmo(AMMO_INFO *ammo);
-static struct json_object_s *SaveGame_BSON_DumpLOT(LOT_INFO *lot);
-static struct json_object_s *SaveGame_BSON_DumpLara(LARA_INFO *lara);
+static struct json_array_s *Savegame_BSON_DumpStartInfo(GAME_INFO *game_info);
+static struct json_array_s *Savegame_BSON_DumpEndInfo(GAME_INFO *game_info);
+static struct json_object_s *Savegame_BSON_DumpMisc(GAME_INFO *game_info);
+static struct json_object_s *Savegame_BSON_DumpInventory();
+static struct json_object_s *Savegame_BSON_DumpFlipmaps();
+static struct json_array_s *Savegame_BSON_DumpCameras();
+static struct json_array_s *Savegame_BSON_DumpItems();
+static struct json_object_s *Savegame_BSON_DumpArm(LARA_ARM *arm);
+static struct json_object_s *Savegame_BSON_DumpAmmo(AMMO_INFO *ammo);
+static struct json_object_s *Savegame_BSON_DumpLOT(LOT_INFO *lot);
+static struct json_object_s *Savegame_BSON_DumpLara(LARA_INFO *lara);
 
-static bool SaveGame_BSON_IsValidItemObject(
+static bool Savegame_BSON_IsValidItemObject(
     int16_t saved_obj_num, int16_t initial_obj_num)
 {
     if (saved_obj_num == initial_obj_num) {
@@ -85,7 +85,7 @@ static bool SaveGame_BSON_IsValidItemObject(
     return false;
 }
 
-static struct json_value_s *SaveGame_BSON_ParseFromBuffer(
+static struct json_value_s *Savegame_BSON_ParseFromBuffer(
     const char *buffer, size_t buffer_size)
 {
     SAVEGAME_BSON_HEADER *header = (SAVEGAME_BSON_HEADER *)buffer;
@@ -112,7 +112,7 @@ static struct json_value_s *SaveGame_BSON_ParseFromBuffer(
     return root;
 }
 
-static struct json_value_s *SaveGame_BSON_ParseFromFile(MYFILE *fp)
+static struct json_value_s *Savegame_BSON_ParseFromFile(MYFILE *fp)
 {
     size_t buffer_size = File_Size(fp);
     char *buffer = Memory_Alloc(buffer_size);
@@ -120,12 +120,12 @@ static struct json_value_s *SaveGame_BSON_ParseFromFile(MYFILE *fp)
     File_Read(buffer, sizeof(char), buffer_size, fp);
 
     struct json_value_s *ret =
-        SaveGame_BSON_ParseFromBuffer(buffer, buffer_size);
+        Savegame_BSON_ParseFromBuffer(buffer, buffer_size);
     Memory_FreePointer(&buffer);
     return ret;
 }
 
-static bool SaveGame_BSON_LoadStartInfo(
+static bool Savegame_BSON_LoadStartInfo(
     struct json_array_s *start_arr, GAME_INFO *game_info)
 {
     assert(game_info);
@@ -173,7 +173,7 @@ static bool SaveGame_BSON_LoadStartInfo(
     return true;
 }
 
-static bool SaveGame_BSON_LoadEndInfo(
+static bool Savegame_BSON_LoadEndInfo(
     struct json_array_s *end_arr, GAME_INFO *game_info)
 {
     assert(game_info);
@@ -214,7 +214,7 @@ static bool SaveGame_BSON_LoadEndInfo(
     return true;
 }
 
-static bool SaveGame_BSON_LoadMisc(
+static bool Savegame_BSON_LoadMisc(
     struct json_object_s *misc_obj, GAME_INFO *game_info)
 {
     assert(game_info);
@@ -226,7 +226,7 @@ static bool SaveGame_BSON_LoadMisc(
     return true;
 }
 
-static bool SaveGame_BSON_LoadInventory(struct json_object_s *inv_obj)
+static bool Savegame_BSON_LoadInventory(struct json_object_s *inv_obj)
 {
     if (!inv_obj) {
         LOG_ERROR("Malformed save: invalid or missing inventory info");
@@ -254,7 +254,7 @@ static bool SaveGame_BSON_LoadInventory(struct json_object_s *inv_obj)
     return true;
 }
 
-static bool SaveGame_BSON_LoadFlipmaps(struct json_object_s *flipmap_obj)
+static bool Savegame_BSON_LoadFlipmaps(struct json_object_s *flipmap_obj)
 {
     if (!flipmap_obj) {
         LOG_ERROR("Malformed save: invalid or missing flipmap info");
@@ -287,7 +287,7 @@ static bool SaveGame_BSON_LoadFlipmaps(struct json_object_s *flipmap_obj)
     return true;
 }
 
-static bool SaveGame_BSON_LoadCameras(struct json_array_s *cameras_arr)
+static bool Savegame_BSON_LoadCameras(struct json_array_s *cameras_arr)
 {
     if (!cameras_arr) {
         LOG_ERROR("Malformed save: invalid or missing cameras array");
@@ -305,7 +305,7 @@ static bool SaveGame_BSON_LoadCameras(struct json_array_s *cameras_arr)
     return true;
 }
 
-static bool SaveGame_BSON_LoadItems(struct json_array_s *items_arr)
+static bool Savegame_BSON_LoadItems(struct json_array_s *items_arr)
 {
     if (!items_arr) {
         LOG_ERROR("Malformed save: invalid or missing items array");
@@ -330,7 +330,7 @@ static bool SaveGame_BSON_LoadItems(struct json_array_s *items_arr)
         OBJECT_INFO *obj = &g_Objects[item->object_number];
 
         int obj_num = json_object_get_int(item_obj, "obj_num", -1);
-        if (!SaveGame_BSON_IsValidItemObject(obj_num, item->object_number)) {
+        if (!Savegame_BSON_IsValidItemObject(obj_num, item->object_number)) {
             LOG_ERROR(
                 "Malformed save: expected object %d, got %d",
                 item->object_number, obj_num);
@@ -420,7 +420,7 @@ static bool SaveGame_BSON_LoadItems(struct json_array_s *items_arr)
     return true;
 }
 
-static bool SaveGame_BSON_LoadArm(struct json_object_s *arm_obj, LARA_ARM *arm)
+static bool Savegame_BSON_LoadArm(struct json_object_s *arm_obj, LARA_ARM *arm)
 {
     assert(arm);
     if (!arm_obj) {
@@ -442,7 +442,7 @@ static bool SaveGame_BSON_LoadArm(struct json_object_s *arm_obj, LARA_ARM *arm)
     return true;
 }
 
-static bool SaveGame_BSON_LoadAmmo(
+static bool Savegame_BSON_LoadAmmo(
     struct json_object_s *ammo_obj, AMMO_INFO *ammo)
 {
     assert(ammo);
@@ -457,7 +457,7 @@ static bool SaveGame_BSON_LoadAmmo(
     return true;
 }
 
-static bool SaveGame_BSON_LoadLOT(struct json_object_s *lot_obj, LOT_INFO *lot)
+static bool Savegame_BSON_LoadLOT(struct json_object_s *lot_obj, LOT_INFO *lot)
 {
     assert(lot);
     if (!lot_obj) {
@@ -486,7 +486,7 @@ static bool SaveGame_BSON_LoadLOT(struct json_object_s *lot_obj, LOT_INFO *lot)
     return true;
 }
 
-static bool SaveGame_BSON_LoadLara(
+static bool Savegame_BSON_LoadLara(
     struct json_object_s *lara_obj, LARA_INFO *lara)
 {
     assert(lara);
@@ -568,37 +568,37 @@ static bool SaveGame_BSON_LoadLara(
     lara->torso_z_rot =
         json_object_get_int(lara_obj, "torso_z_rot", lara->torso_z_rot);
 
-    if (!SaveGame_BSON_LoadArm(
+    if (!Savegame_BSON_LoadArm(
             json_object_get_object(lara_obj, "left_arm"), &lara->left_arm)) {
         return false;
     }
 
-    if (!SaveGame_BSON_LoadArm(
+    if (!Savegame_BSON_LoadArm(
             json_object_get_object(lara_obj, "right_arm"), &lara->right_arm)) {
         return false;
     }
 
-    if (!SaveGame_BSON_LoadAmmo(
+    if (!Savegame_BSON_LoadAmmo(
             json_object_get_object(lara_obj, "pistols"), &lara->pistols)) {
         return false;
     }
 
-    if (!SaveGame_BSON_LoadAmmo(
+    if (!Savegame_BSON_LoadAmmo(
             json_object_get_object(lara_obj, "magnums"), &lara->magnums)) {
         return false;
     }
 
-    if (!SaveGame_BSON_LoadAmmo(
+    if (!Savegame_BSON_LoadAmmo(
             json_object_get_object(lara_obj, "uzis"), &lara->uzis)) {
         return false;
     }
 
-    if (!SaveGame_BSON_LoadAmmo(
+    if (!Savegame_BSON_LoadAmmo(
             json_object_get_object(lara_obj, "shotgun"), &lara->shotgun)) {
         return false;
     }
 
-    if (!SaveGame_BSON_LoadLOT(
+    if (!Savegame_BSON_LoadLOT(
             json_object_get_object(lara_obj, "lot"), &lara->LOT)) {
         return false;
     }
@@ -606,7 +606,7 @@ static bool SaveGame_BSON_LoadLara(
     return true;
 }
 
-static struct json_array_s *SaveGame_BSON_DumpStartInfo(GAME_INFO *game_info)
+static struct json_array_s *Savegame_BSON_DumpStartInfo(GAME_INFO *game_info)
 {
     struct json_array_s *start_arr = json_array_new();
     assert(game_info->start);
@@ -639,7 +639,7 @@ static struct json_array_s *SaveGame_BSON_DumpStartInfo(GAME_INFO *game_info)
     return start_arr;
 }
 
-static struct json_array_s *SaveGame_BSON_DumpEndInfo(GAME_INFO *game_info)
+static struct json_array_s *Savegame_BSON_DumpEndInfo(GAME_INFO *game_info)
 {
     struct json_array_s *end_arr = json_array_new();
     assert(game_info->end);
@@ -660,7 +660,7 @@ static struct json_array_s *SaveGame_BSON_DumpEndInfo(GAME_INFO *game_info)
     return end_arr;
 }
 
-static struct json_object_s *SaveGame_BSON_DumpMisc(GAME_INFO *game_info)
+static struct json_object_s *Savegame_BSON_DumpMisc(GAME_INFO *game_info)
 {
     assert(game_info);
     struct json_object_s *misc_obj = json_object_new();
@@ -668,7 +668,7 @@ static struct json_object_s *SaveGame_BSON_DumpMisc(GAME_INFO *game_info)
     return misc_obj;
 }
 
-static struct json_object_s *SaveGame_BSON_DumpInventory()
+static struct json_object_s *Savegame_BSON_DumpInventory()
 {
     // TODO: save this info for every level
     struct json_object_s *inv_obj = json_object_new();
@@ -686,7 +686,7 @@ static struct json_object_s *SaveGame_BSON_DumpInventory()
     return inv_obj;
 }
 
-static struct json_object_s *SaveGame_BSON_DumpFlipmaps()
+static struct json_object_s *Savegame_BSON_DumpFlipmaps()
 {
     struct json_object_s *flipmap_obj = json_object_new();
     json_object_append_bool(flipmap_obj, "status", g_FlipStatus);
@@ -700,7 +700,7 @@ static struct json_object_s *SaveGame_BSON_DumpFlipmaps()
     return flipmap_obj;
 }
 
-static struct json_array_s *SaveGame_BSON_DumpCameras()
+static struct json_array_s *Savegame_BSON_DumpCameras()
 {
     struct json_array_s *cameras_arr = json_array_new();
     for (int i = 0; i < g_NumberCameras; i++) {
@@ -709,7 +709,7 @@ static struct json_array_s *SaveGame_BSON_DumpCameras()
     return cameras_arr;
 }
 
-static struct json_array_s *SaveGame_BSON_DumpItems()
+static struct json_array_s *Savegame_BSON_DumpItems()
 {
     struct json_array_s *items_arr = json_array_new();
     for (int i = 0; i < g_LevelItemCount; i++) {
@@ -775,7 +775,7 @@ static struct json_array_s *SaveGame_BSON_DumpItems()
     return items_arr;
 }
 
-static struct json_object_s *SaveGame_BSON_DumpArm(LARA_ARM *arm)
+static struct json_object_s *Savegame_BSON_DumpArm(LARA_ARM *arm)
 {
     assert(arm);
     struct json_object_s *arm_obj = json_object_new();
@@ -790,7 +790,7 @@ static struct json_object_s *SaveGame_BSON_DumpArm(LARA_ARM *arm)
     return arm_obj;
 }
 
-static struct json_object_s *SaveGame_BSON_DumpAmmo(AMMO_INFO *ammo)
+static struct json_object_s *Savegame_BSON_DumpAmmo(AMMO_INFO *ammo)
 {
     assert(ammo);
     struct json_object_s *ammo_obj = json_object_new();
@@ -800,7 +800,7 @@ static struct json_object_s *SaveGame_BSON_DumpAmmo(AMMO_INFO *ammo)
     return ammo_obj;
 }
 
-static struct json_object_s *SaveGame_BSON_DumpLOT(LOT_INFO *lot)
+static struct json_object_s *Savegame_BSON_DumpLOT(LOT_INFO *lot)
 {
     assert(lot);
     struct json_object_s *lot_obj = json_object_new();
@@ -821,7 +821,7 @@ static struct json_object_s *SaveGame_BSON_DumpLOT(LOT_INFO *lot)
     return lot_obj;
 }
 
-static struct json_object_s *SaveGame_BSON_DumpLara(LARA_INFO *lara)
+static struct json_object_s *Savegame_BSON_DumpLara(LARA_INFO *lara)
 {
     assert(lara);
     struct json_object_s *lara_obj = json_object_new();
@@ -865,24 +865,24 @@ static struct json_object_s *SaveGame_BSON_DumpLara(LARA_INFO *lara)
     json_object_append_int(lara_obj, "torso_z_rot", lara->torso_z_rot);
 
     json_object_append_object(
-        lara_obj, "left_arm", SaveGame_BSON_DumpArm(&lara->left_arm));
+        lara_obj, "left_arm", Savegame_BSON_DumpArm(&lara->left_arm));
     json_object_append_object(
-        lara_obj, "right_arm", SaveGame_BSON_DumpArm(&lara->right_arm));
+        lara_obj, "right_arm", Savegame_BSON_DumpArm(&lara->right_arm));
     json_object_append_object(
-        lara_obj, "pistols", SaveGame_BSON_DumpAmmo(&lara->pistols));
+        lara_obj, "pistols", Savegame_BSON_DumpAmmo(&lara->pistols));
     json_object_append_object(
-        lara_obj, "magnums", SaveGame_BSON_DumpAmmo(&lara->magnums));
+        lara_obj, "magnums", Savegame_BSON_DumpAmmo(&lara->magnums));
     json_object_append_object(
-        lara_obj, "uzis", SaveGame_BSON_DumpAmmo(&lara->uzis));
+        lara_obj, "uzis", Savegame_BSON_DumpAmmo(&lara->uzis));
     json_object_append_object(
-        lara_obj, "shotgun", SaveGame_BSON_DumpAmmo(&lara->shotgun));
+        lara_obj, "shotgun", Savegame_BSON_DumpAmmo(&lara->shotgun));
     json_object_append_object(
-        lara_obj, "lot", SaveGame_BSON_DumpLOT(&lara->LOT));
+        lara_obj, "lot", Savegame_BSON_DumpLOT(&lara->LOT));
 
     return lara_obj;
 }
 
-char *SaveGame_BSON_GetSaveFileName(int32_t slot)
+char *Savegame_BSON_GetSaveFileName(int32_t slot)
 {
     size_t out_size = snprintf(NULL, 0, g_GameFlow.savegame_fmt_bson, slot) + 1;
     char *out = Memory_Alloc(out_size);
@@ -890,10 +890,10 @@ char *SaveGame_BSON_GetSaveFileName(int32_t slot)
     return out;
 }
 
-bool SaveGame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info)
+bool Savegame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info)
 {
     bool ret = false;
-    struct json_value_s *root = SaveGame_BSON_ParseFromFile(fp);
+    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp);
     struct json_object_s *root_obj = json_value_as_object(root);
     if (root_obj) {
         info->counter = json_object_get_int(root_obj, "save_counter", -1);
@@ -909,12 +909,12 @@ bool SaveGame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info)
     return ret;
 }
 
-bool SaveGame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
+bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
 {
     assert(game_info);
 
     bool ret = false;
-    struct json_value_s *root = SaveGame_BSON_ParseFromFile(fp);
+    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp);
     struct json_object_s *root_obj = json_value_as_object(root);
     if (!root_obj) {
         LOG_ERROR("Malformed save: cannot parse BSON data");
@@ -927,36 +927,36 @@ bool SaveGame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         goto cleanup;
     }
 
-    if (!SaveGame_BSON_LoadStartInfo(
+    if (!Savegame_BSON_LoadStartInfo(
             json_object_get_array(root_obj, "start_info"), game_info)) {
         goto cleanup;
     }
 
-    if (!SaveGame_BSON_LoadEndInfo(
+    if (!Savegame_BSON_LoadEndInfo(
             json_object_get_array(root_obj, "end_info"), game_info)) {
         goto cleanup;
     }
 
-    if (!SaveGame_BSON_LoadInventory(
+    if (!Savegame_BSON_LoadInventory(
             json_object_get_object(root_obj, "inventory"))) {
         goto cleanup;
     }
 
-    if (!SaveGame_BSON_LoadFlipmaps(
+    if (!Savegame_BSON_LoadFlipmaps(
             json_object_get_object(root_obj, "flipmap"))) {
         goto cleanup;
     }
 
-    if (!SaveGame_BSON_LoadCameras(
+    if (!Savegame_BSON_LoadCameras(
             json_object_get_array(root_obj, "cameras"))) {
         goto cleanup;
     }
 
-    if (!SaveGame_BSON_LoadItems(json_object_get_array(root_obj, "items"))) {
+    if (!Savegame_BSON_LoadItems(json_object_get_array(root_obj, "items"))) {
         goto cleanup;
     }
 
-    if (!SaveGame_BSON_LoadLara(
+    if (!Savegame_BSON_LoadLara(
             json_object_get_object(root_obj, "lara"), &g_Lara)) {
         goto cleanup;
     }
@@ -968,7 +968,7 @@ cleanup:
     return ret;
 }
 
-void SaveGame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
+void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
 {
     assert(game_info);
 
@@ -980,19 +980,19 @@ void SaveGame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
     json_object_append_int(root_obj, "level_num", g_CurrentLevel);
 
     json_object_append_object(
-        root_obj, "misc", SaveGame_BSON_DumpMisc(game_info));
+        root_obj, "misc", Savegame_BSON_DumpMisc(game_info));
     json_object_append_array(
-        root_obj, "start_info", SaveGame_BSON_DumpStartInfo(game_info));
+        root_obj, "start_info", Savegame_BSON_DumpStartInfo(game_info));
     json_object_append_array(
-        root_obj, "end_info", SaveGame_BSON_DumpEndInfo(game_info));
+        root_obj, "end_info", Savegame_BSON_DumpEndInfo(game_info));
     json_object_append_object(
-        root_obj, "inventory", SaveGame_BSON_DumpInventory());
+        root_obj, "inventory", Savegame_BSON_DumpInventory());
     json_object_append_object(
-        root_obj, "flipmap", SaveGame_BSON_DumpFlipmaps());
-    json_object_append_array(root_obj, "cameras", SaveGame_BSON_DumpCameras());
-    json_object_append_array(root_obj, "items", SaveGame_BSON_DumpItems());
+        root_obj, "flipmap", Savegame_BSON_DumpFlipmaps());
+    json_object_append_array(root_obj, "cameras", Savegame_BSON_DumpCameras());
+    json_object_append_array(root_obj, "items", Savegame_BSON_DumpItems());
     json_object_append_object(
-        root_obj, "lara", SaveGame_BSON_DumpLara(&g_Lara));
+        root_obj, "lara", Savegame_BSON_DumpLara(&g_Lara));
 
     size_t uncompressed_size;
     struct json_value_s *root = json_value_from_object(root_obj);

--- a/src/game/savegame_bson.h
+++ b/src/game/savegame_bson.h
@@ -8,7 +8,7 @@
 
 // Tomb1Main implementation of savegames.
 
-char *SaveGame_BSON_GetSaveFileName(int32_t slot);
-bool SaveGame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info);
-bool SaveGame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info);
-void SaveGame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info);
+char *Savegame_BSON_GetSaveFileName(int32_t slot);
+bool Savegame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info);
+bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info);
+void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info);

--- a/src/game/savegame_common.h
+++ b/src/game/savegame_common.h
@@ -14,3 +14,9 @@ typedef struct SAVEGAME_INFO {
     int32_t level_num;
     char *level_title;
 } SAVEGAME_INFO;
+
+void ResetStartInfo(int level_num);
+void CreateStartInfo(int level_num);
+void ModifyStartInfo(int level_num);
+void ResetEndInfo(int level_num);
+void CreateEndInfo(int level_num);

--- a/src/game/savegame_common.h
+++ b/src/game/savegame_common.h
@@ -15,8 +15,8 @@ typedef struct SAVEGAME_INFO {
     char *level_title;
 } SAVEGAME_INFO;
 
-void ResetStartInfo(int level_num);
-void CreateStartInfo(int level_num);
-void ModifyStartInfo(int level_num);
-void ResetEndInfo(int level_num);
-void CreateEndInfo(int level_num);
+void Savegame_ResetStartInfo(int level_num);
+void Savegame_PersistGameToStartInfo(int level_num);
+void Savegame_ApplyLogicToStartInfo(int level_num);
+void Savegame_ResetEndInfo(int level_num);
+void Savegame_PersistGameToEndInfo(int level_num);

--- a/src/game/savegame_legacy.c
+++ b/src/game/savegame_legacy.c
@@ -431,12 +431,17 @@ bool SaveGame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         SaveGame_Legacy_Read(&start->flags, sizeof(uint16_t));
     }
 
-    SaveGame_Legacy_Read(&game_info->timer, sizeof(uint32_t));
-    SaveGame_Legacy_Read(&game_info->kills, sizeof(uint32_t));
-    SaveGame_Legacy_Read(&game_info->secrets, sizeof(uint16_t));
+    SaveGame_Legacy_Read(&game_info->stats.timer, sizeof(uint32_t));
+    SaveGame_Legacy_Read(&game_info->stats.kill_count, sizeof(uint32_t));
+    SaveGame_Legacy_Read(&game_info->stats.secret_flags, sizeof(uint16_t));
     SaveGame_Legacy_Read(&g_CurrentLevel, sizeof(uint16_t));
-    SaveGame_Legacy_Read(&game_info->pickups, sizeof(uint8_t));
+    SaveGame_Legacy_Read(&game_info->stats.pickup_count, sizeof(uint8_t));
     SaveGame_Legacy_Read(&game_info->bonus_flag, sizeof(uint8_t));
+
+    for (int i = 0; i < g_GameFlow.level_count; i++) {
+        ResetEndInfo(i);
+    }
+    game_info->end[g_CurrentLevel].stats = game_info->stats;
 
     InitialiseLaraInventory(g_CurrentLevel);
     SAVEGAME_LEGACY_ITEM_STATS item_stats = { 0 };
@@ -574,11 +579,11 @@ void SaveGame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
         SaveGame_Legacy_Write(&start->flags, sizeof(uint16_t));
     }
 
-    SaveGame_Legacy_Write(&game_info->timer, sizeof(uint32_t));
-    SaveGame_Legacy_Write(&game_info->kills, sizeof(uint32_t));
-    SaveGame_Legacy_Write(&game_info->secrets, sizeof(uint16_t));
+    SaveGame_Legacy_Write(&game_info->stats.timer, sizeof(uint32_t));
+    SaveGame_Legacy_Write(&game_info->stats.kill_count, sizeof(uint32_t));
+    SaveGame_Legacy_Write(&game_info->stats.secret_flags, sizeof(uint16_t));
     SaveGame_Legacy_Write(&g_CurrentLevel, sizeof(uint16_t));
-    SaveGame_Legacy_Write(&game_info->pickups, sizeof(uint8_t));
+    SaveGame_Legacy_Write(&game_info->stats.pickup_count, sizeof(uint8_t));
     SaveGame_Legacy_Write(&game_info->bonus_flag, sizeof(uint8_t));
 
     SAVEGAME_LEGACY_ITEM_STATS item_stats = {

--- a/src/game/savegame_legacy.c
+++ b/src/game/savegame_legacy.c
@@ -37,22 +37,22 @@ typedef struct SAVEGAME_LEGACY_ITEM_STATS {
 static int m_SGBufPos = 0;
 static char *m_SGBufPtr = NULL;
 
-static bool SaveGame_Legacy_NeedsEvilLaraFix();
+static bool Savegame_Legacy_NeedsEvilLaraFix();
 
-static void SaveGame_Legacy_Reset(char *buffer);
-static void SaveGame_Legacy_Skip(int size);
+static void Savegame_Legacy_Reset(char *buffer);
+static void Savegame_Legacy_Skip(int size);
 
-static void SaveGame_Legacy_Read(void *pointer, int size);
-static void SaveGame_Legacy_ReadArm(LARA_ARM *arm);
-static void SaveGame_Legacy_ReadLara(LARA_INFO *lara);
-static void SaveGame_Legacy_ReadLOT(LOT_INFO *lot);
+static void Savegame_Legacy_Read(void *pointer, int size);
+static void Savegame_Legacy_ReadArm(LARA_ARM *arm);
+static void Savegame_Legacy_ReadLara(LARA_INFO *lara);
+static void Savegame_Legacy_ReadLOT(LOT_INFO *lot);
 
-static void SaveGame_Legacy_Write(void *pointer, int size);
-static void SaveGame_Legacy_WriteArm(LARA_ARM *arm);
-static void SaveGame_Legacy_WriteLara(LARA_INFO *lara);
-static void SaveGame_Legacy_WriteLOT(LOT_INFO *lot);
+static void Savegame_Legacy_Write(void *pointer, int size);
+static void Savegame_Legacy_WriteArm(LARA_ARM *arm);
+static void Savegame_Legacy_WriteLara(LARA_INFO *lara);
+static void Savegame_Legacy_WriteLOT(LOT_INFO *lot);
 
-static bool SaveGame_Legacy_NeedsEvilLaraFix(char *buffer)
+static bool Savegame_Legacy_NeedsEvilLaraFix(char *buffer)
 {
     // Heuristic for issue #261.
     // Tomb1Main enables save_flags for Evil Lara, but OG TombATI does not. As
@@ -73,31 +73,31 @@ static bool SaveGame_Legacy_NeedsEvilLaraFix(char *buffer)
         return result;
     }
 
-    SaveGame_Legacy_Reset(buffer);
-    SaveGame_Legacy_Skip(SAVEGAME_LEGACY_TITLE_SIZE); // level title
-    SaveGame_Legacy_Skip(sizeof(int32_t)); // save counter
+    Savegame_Legacy_Reset(buffer);
+    Savegame_Legacy_Skip(SAVEGAME_LEGACY_TITLE_SIZE); // level title
+    Savegame_Legacy_Skip(sizeof(int32_t)); // save counter
     for (int i = 0; i < g_GameFlow.level_count; i++) {
-        SaveGame_Legacy_Skip(sizeof(uint16_t)); // pistol ammo
-        SaveGame_Legacy_Skip(sizeof(uint16_t)); // magnum ammo
-        SaveGame_Legacy_Skip(sizeof(uint16_t)); // uzi ammo
-        SaveGame_Legacy_Skip(sizeof(uint16_t)); // shotgun ammo
-        SaveGame_Legacy_Skip(sizeof(uint8_t)); // small medis
-        SaveGame_Legacy_Skip(sizeof(uint8_t)); // big medis
-        SaveGame_Legacy_Skip(sizeof(uint8_t)); // scions
-        SaveGame_Legacy_Skip(sizeof(int8_t)); // gun status
-        SaveGame_Legacy_Skip(sizeof(int8_t)); // gun type
-        SaveGame_Legacy_Skip(sizeof(uint16_t)); // flags
+        Savegame_Legacy_Skip(sizeof(uint16_t)); // pistol ammo
+        Savegame_Legacy_Skip(sizeof(uint16_t)); // magnum ammo
+        Savegame_Legacy_Skip(sizeof(uint16_t)); // uzi ammo
+        Savegame_Legacy_Skip(sizeof(uint16_t)); // shotgun ammo
+        Savegame_Legacy_Skip(sizeof(uint8_t)); // small medis
+        Savegame_Legacy_Skip(sizeof(uint8_t)); // big medis
+        Savegame_Legacy_Skip(sizeof(uint8_t)); // scions
+        Savegame_Legacy_Skip(sizeof(int8_t)); // gun status
+        Savegame_Legacy_Skip(sizeof(int8_t)); // gun type
+        Savegame_Legacy_Skip(sizeof(uint16_t)); // flags
     }
-    SaveGame_Legacy_Skip(sizeof(uint32_t)); // timer
-    SaveGame_Legacy_Skip(sizeof(uint32_t)); // kills
-    SaveGame_Legacy_Skip(sizeof(uint16_t)); // secrets
-    SaveGame_Legacy_Skip(sizeof(uint16_t)); // current level
-    SaveGame_Legacy_Skip(sizeof(uint8_t)); // pickups
-    SaveGame_Legacy_Skip(sizeof(uint8_t)); // bonus_flag
-    SaveGame_Legacy_Skip(sizeof(SAVEGAME_LEGACY_ITEM_STATS)); // item stats
-    SaveGame_Legacy_Skip(sizeof(int32_t)); // flipmap status
-    SaveGame_Legacy_Skip(MAX_FLIP_MAPS * sizeof(int8_t)); // flipmap table
-    SaveGame_Legacy_Skip(g_NumberCameras * sizeof(int16_t)); // cameras
+    Savegame_Legacy_Skip(sizeof(uint32_t)); // timer
+    Savegame_Legacy_Skip(sizeof(uint32_t)); // kills
+    Savegame_Legacy_Skip(sizeof(uint16_t)); // secrets
+    Savegame_Legacy_Skip(sizeof(uint16_t)); // current level
+    Savegame_Legacy_Skip(sizeof(uint8_t)); // pickups
+    Savegame_Legacy_Skip(sizeof(uint8_t)); // bonus_flag
+    Savegame_Legacy_Skip(sizeof(SAVEGAME_LEGACY_ITEM_STATS)); // item stats
+    Savegame_Legacy_Skip(sizeof(int32_t)); // flipmap status
+    Savegame_Legacy_Skip(MAX_FLIP_MAPS * sizeof(int8_t)); // flipmap table
+    Savegame_Legacy_Skip(g_NumberCameras * sizeof(int16_t)); // cameras
 
     for (int i = 0; i < g_LevelItemCount; i++) {
         ITEM_INFO *item = &g_Items[i];
@@ -106,35 +106,35 @@ static bool SaveGame_Legacy_NeedsEvilLaraFix(char *buffer)
         ITEM_INFO tmp_item;
 
         if (obj->save_position) {
-            SaveGame_Legacy_Read(&tmp_item.pos, sizeof(PHD_3DPOS));
-            SaveGame_Legacy_Skip(sizeof(int16_t));
-            SaveGame_Legacy_Read(&tmp_item.speed, sizeof(int16_t));
-            SaveGame_Legacy_Read(&tmp_item.fall_speed, sizeof(int16_t));
+            Savegame_Legacy_Read(&tmp_item.pos, sizeof(PHD_3DPOS));
+            Savegame_Legacy_Skip(sizeof(int16_t));
+            Savegame_Legacy_Read(&tmp_item.speed, sizeof(int16_t));
+            Savegame_Legacy_Read(&tmp_item.fall_speed, sizeof(int16_t));
         }
         if (obj->save_anim) {
-            SaveGame_Legacy_Read(&tmp_item.current_anim_state, sizeof(int16_t));
-            SaveGame_Legacy_Read(&tmp_item.goal_anim_state, sizeof(int16_t));
-            SaveGame_Legacy_Read(
+            Savegame_Legacy_Read(&tmp_item.current_anim_state, sizeof(int16_t));
+            Savegame_Legacy_Read(&tmp_item.goal_anim_state, sizeof(int16_t));
+            Savegame_Legacy_Read(
                 &tmp_item.required_anim_state, sizeof(int16_t));
-            SaveGame_Legacy_Read(&tmp_item.anim_number, sizeof(int16_t));
-            SaveGame_Legacy_Read(&tmp_item.frame_number, sizeof(int16_t));
+            Savegame_Legacy_Read(&tmp_item.anim_number, sizeof(int16_t));
+            Savegame_Legacy_Read(&tmp_item.frame_number, sizeof(int16_t));
         }
         if (obj->save_hitpoints) {
-            SaveGame_Legacy_Read(&tmp_item.hit_points, sizeof(int16_t));
+            Savegame_Legacy_Read(&tmp_item.hit_points, sizeof(int16_t));
         }
         if (obj->save_flags) {
-            SaveGame_Legacy_Read(&tmp_item.flags, sizeof(int16_t));
-            SaveGame_Legacy_Read(&tmp_item.timer, sizeof(int16_t));
+            Savegame_Legacy_Read(&tmp_item.flags, sizeof(int16_t));
+            Savegame_Legacy_Read(&tmp_item.timer, sizeof(int16_t));
             if (tmp_item.flags & SAVE_CREATURE) {
                 CREATURE_INFO tmp_creature;
-                SaveGame_Legacy_Read(
+                Savegame_Legacy_Read(
                     &tmp_creature.head_rotation, sizeof(int16_t));
-                SaveGame_Legacy_Read(
+                Savegame_Legacy_Read(
                     &tmp_creature.neck_rotation, sizeof(int16_t));
-                SaveGame_Legacy_Read(
+                Savegame_Legacy_Read(
                     &tmp_creature.maximum_turn, sizeof(int16_t));
-                SaveGame_Legacy_Read(&tmp_creature.flags, sizeof(int16_t));
-                SaveGame_Legacy_Read(&tmp_creature.mood, sizeof(int32_t));
+                Savegame_Legacy_Read(&tmp_creature.flags, sizeof(int16_t));
+                Savegame_Legacy_Read(&tmp_creature.mood, sizeof(int32_t));
             }
         }
 
@@ -148,19 +148,19 @@ static bool SaveGame_Legacy_NeedsEvilLaraFix(char *buffer)
     return result;
 }
 
-static void SaveGame_Legacy_Reset(char *buffer)
+static void Savegame_Legacy_Reset(char *buffer)
 {
     m_SGBufPos = 0;
     m_SGBufPtr = buffer;
 }
 
-static void SaveGame_Legacy_Skip(int size)
+static void Savegame_Legacy_Skip(int size)
 {
     m_SGBufPtr += size;
     m_SGBufPos += size; // missing from OG
 }
 
-static void SaveGame_Legacy_Write(void *pointer, int size)
+static void Savegame_Legacy_Write(void *pointer, int size)
 {
     m_SGBufPos += size;
     if (m_SGBufPos >= SAVEGAME_LEGACY_MAX_BUFFER_SIZE) {
@@ -173,94 +173,94 @@ static void SaveGame_Legacy_Write(void *pointer, int size)
     }
 }
 
-static void SaveGame_Legacy_WriteLara(LARA_INFO *lara)
+static void Savegame_Legacy_WriteLara(LARA_INFO *lara)
 {
     int32_t tmp32 = 0;
 
-    SaveGame_Legacy_Write(&lara->item_number, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->gun_status, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->gun_type, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->request_gun_type, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->calc_fall_speed, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->water_status, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->pose_count, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->hit_frame, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->hit_direction, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->air, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->dive_count, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->death_count, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->current_active, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->spaz_effect_count, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->item_number, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->gun_status, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->gun_type, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->request_gun_type, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->calc_fall_speed, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->water_status, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->pose_count, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->hit_frame, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->hit_direction, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->air, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->dive_count, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->death_count, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->current_active, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->spaz_effect_count, sizeof(int16_t));
 
     // OG just writes the pointer address (!)
     if (lara->spaz_effect) {
         tmp32 = (size_t)lara->spaz_effect - (size_t)g_Effects;
     }
-    SaveGame_Legacy_Write(&tmp32, sizeof(int32_t));
+    Savegame_Legacy_Write(&tmp32, sizeof(int32_t));
 
-    SaveGame_Legacy_Write(&lara->mesh_effects, sizeof(int32_t));
+    Savegame_Legacy_Write(&lara->mesh_effects, sizeof(int32_t));
 
     for (int i = 0; i < LM_NUMBER_OF; i++) {
         tmp32 = (size_t)lara->mesh_ptrs[i] - (size_t)g_MeshBase;
-        SaveGame_Legacy_Write(&tmp32, sizeof(int32_t));
+        Savegame_Legacy_Write(&tmp32, sizeof(int32_t));
     }
 
     // OG just writes the pointer address (!) assuming it's a non-existing mesh
     // 16 (!!) which happens to be g_Lara's current target. Just write NULL.
     tmp32 = 0;
-    SaveGame_Legacy_Write(&tmp32, sizeof(int32_t));
+    Savegame_Legacy_Write(&tmp32, sizeof(int32_t));
 
-    SaveGame_Legacy_Write(&lara->target_angles[0], sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Write(&lara->target_angles[1], sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Write(&lara->turn_rate, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->move_angle, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->head_y_rot, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->head_x_rot, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->head_z_rot, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->torso_y_rot, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->torso_x_rot, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lara->torso_z_rot, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->target_angles[0], sizeof(PHD_ANGLE));
+    Savegame_Legacy_Write(&lara->target_angles[1], sizeof(PHD_ANGLE));
+    Savegame_Legacy_Write(&lara->turn_rate, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->move_angle, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->head_y_rot, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->head_x_rot, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->head_z_rot, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->torso_y_rot, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->torso_x_rot, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->torso_z_rot, sizeof(int16_t));
 
-    SaveGame_Legacy_WriteArm(&lara->left_arm);
-    SaveGame_Legacy_WriteArm(&lara->right_arm);
-    SaveGame_Legacy_Write(&lara->pistols, sizeof(AMMO_INFO));
-    SaveGame_Legacy_Write(&lara->magnums, sizeof(AMMO_INFO));
-    SaveGame_Legacy_Write(&lara->uzis, sizeof(AMMO_INFO));
-    SaveGame_Legacy_Write(&lara->shotgun, sizeof(AMMO_INFO));
-    SaveGame_Legacy_WriteLOT(&lara->LOT);
+    Savegame_Legacy_WriteArm(&lara->left_arm);
+    Savegame_Legacy_WriteArm(&lara->right_arm);
+    Savegame_Legacy_Write(&lara->pistols, sizeof(AMMO_INFO));
+    Savegame_Legacy_Write(&lara->magnums, sizeof(AMMO_INFO));
+    Savegame_Legacy_Write(&lara->uzis, sizeof(AMMO_INFO));
+    Savegame_Legacy_Write(&lara->shotgun, sizeof(AMMO_INFO));
+    Savegame_Legacy_WriteLOT(&lara->LOT);
 }
 
-static void SaveGame_Legacy_WriteArm(LARA_ARM *arm)
+static void Savegame_Legacy_WriteArm(LARA_ARM *arm)
 {
     int32_t frame_base = (size_t)arm->frame_base - (size_t)g_AnimFrames;
-    SaveGame_Legacy_Write(&frame_base, sizeof(int32_t));
-    SaveGame_Legacy_Write(&arm->frame_number, sizeof(int16_t));
-    SaveGame_Legacy_Write(&arm->lock, sizeof(int16_t));
-    SaveGame_Legacy_Write(&arm->y_rot, sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Write(&arm->x_rot, sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Write(&arm->z_rot, sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Write(&arm->flash_gun, sizeof(int16_t));
+    Savegame_Legacy_Write(&frame_base, sizeof(int32_t));
+    Savegame_Legacy_Write(&arm->frame_number, sizeof(int16_t));
+    Savegame_Legacy_Write(&arm->lock, sizeof(int16_t));
+    Savegame_Legacy_Write(&arm->y_rot, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Write(&arm->x_rot, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Write(&arm->z_rot, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Write(&arm->flash_gun, sizeof(int16_t));
 }
 
-static void SaveGame_Legacy_WriteLOT(LOT_INFO *lot)
+static void Savegame_Legacy_WriteLOT(LOT_INFO *lot)
 {
     // it casually saves a pointer again!
-    SaveGame_Legacy_Write(&lot->node, sizeof(int32_t));
+    Savegame_Legacy_Write(&lot->node, sizeof(int32_t));
 
-    SaveGame_Legacy_Write(&lot->head, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lot->tail, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lot->search_number, sizeof(uint16_t));
-    SaveGame_Legacy_Write(&lot->block_mask, sizeof(uint16_t));
-    SaveGame_Legacy_Write(&lot->step, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lot->drop, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lot->fly, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lot->zone_count, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lot->target_box, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lot->required_box, sizeof(int16_t));
-    SaveGame_Legacy_Write(&lot->target, sizeof(PHD_VECTOR));
+    Savegame_Legacy_Write(&lot->head, sizeof(int16_t));
+    Savegame_Legacy_Write(&lot->tail, sizeof(int16_t));
+    Savegame_Legacy_Write(&lot->search_number, sizeof(uint16_t));
+    Savegame_Legacy_Write(&lot->block_mask, sizeof(uint16_t));
+    Savegame_Legacy_Write(&lot->step, sizeof(int16_t));
+    Savegame_Legacy_Write(&lot->drop, sizeof(int16_t));
+    Savegame_Legacy_Write(&lot->fly, sizeof(int16_t));
+    Savegame_Legacy_Write(&lot->zone_count, sizeof(int16_t));
+    Savegame_Legacy_Write(&lot->target_box, sizeof(int16_t));
+    Savegame_Legacy_Write(&lot->required_box, sizeof(int16_t));
+    Savegame_Legacy_Write(&lot->target, sizeof(PHD_VECTOR));
 }
 
-static void SaveGame_Legacy_Read(void *pointer, int size)
+static void Savegame_Legacy_Read(void *pointer, int size)
 {
     m_SGBufPos += size;
     char *data = (char *)pointer;
@@ -268,90 +268,90 @@ static void SaveGame_Legacy_Read(void *pointer, int size)
         *data++ = *m_SGBufPtr++;
 }
 
-static void SaveGame_Legacy_ReadLara(LARA_INFO *lara)
+static void Savegame_Legacy_ReadLara(LARA_INFO *lara)
 {
     int32_t tmp32 = 0;
 
-    SaveGame_Legacy_Read(&lara->item_number, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->gun_status, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->gun_type, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->request_gun_type, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->calc_fall_speed, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->water_status, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->pose_count, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->hit_frame, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->hit_direction, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->air, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->dive_count, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->death_count, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->current_active, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->spaz_effect_count, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->item_number, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->gun_status, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->gun_type, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->request_gun_type, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->calc_fall_speed, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->water_status, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->pose_count, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->hit_frame, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->hit_direction, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->air, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->dive_count, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->death_count, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->current_active, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->spaz_effect_count, sizeof(int16_t));
 
     lara->spaz_effect = NULL;
-    SaveGame_Legacy_Skip(sizeof(FX_INFO *));
+    Savegame_Legacy_Skip(sizeof(FX_INFO *));
 
-    SaveGame_Legacy_Read(&lara->mesh_effects, sizeof(int32_t));
+    Savegame_Legacy_Read(&lara->mesh_effects, sizeof(int32_t));
     for (int i = 0; i < LM_NUMBER_OF; i++) {
-        SaveGame_Legacy_Read(&tmp32, sizeof(int32_t));
+        Savegame_Legacy_Read(&tmp32, sizeof(int32_t));
         lara->mesh_ptrs[i] = (int16_t *)((size_t)g_MeshBase + (size_t)tmp32);
     }
 
     lara->target = NULL;
-    SaveGame_Legacy_Skip(sizeof(ITEM_INFO *));
+    Savegame_Legacy_Skip(sizeof(ITEM_INFO *));
 
-    SaveGame_Legacy_Read(&lara->target_angles[0], sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Read(&lara->target_angles[1], sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Read(&lara->turn_rate, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->move_angle, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->head_y_rot, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->head_x_rot, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->head_z_rot, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->torso_y_rot, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->torso_x_rot, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lara->torso_z_rot, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->target_angles[0], sizeof(PHD_ANGLE));
+    Savegame_Legacy_Read(&lara->target_angles[1], sizeof(PHD_ANGLE));
+    Savegame_Legacy_Read(&lara->turn_rate, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->move_angle, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->head_y_rot, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->head_x_rot, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->head_z_rot, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->torso_y_rot, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->torso_x_rot, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->torso_z_rot, sizeof(int16_t));
 
-    SaveGame_Legacy_ReadArm(&lara->left_arm);
-    SaveGame_Legacy_ReadArm(&lara->right_arm);
-    SaveGame_Legacy_Read(&lara->pistols, sizeof(AMMO_INFO));
-    SaveGame_Legacy_Read(&lara->magnums, sizeof(AMMO_INFO));
-    SaveGame_Legacy_Read(&lara->uzis, sizeof(AMMO_INFO));
-    SaveGame_Legacy_Read(&lara->shotgun, sizeof(AMMO_INFO));
-    SaveGame_Legacy_ReadLOT(&lara->LOT);
+    Savegame_Legacy_ReadArm(&lara->left_arm);
+    Savegame_Legacy_ReadArm(&lara->right_arm);
+    Savegame_Legacy_Read(&lara->pistols, sizeof(AMMO_INFO));
+    Savegame_Legacy_Read(&lara->magnums, sizeof(AMMO_INFO));
+    Savegame_Legacy_Read(&lara->uzis, sizeof(AMMO_INFO));
+    Savegame_Legacy_Read(&lara->shotgun, sizeof(AMMO_INFO));
+    Savegame_Legacy_ReadLOT(&lara->LOT);
 }
 
-static void SaveGame_Legacy_ReadArm(LARA_ARM *arm)
+static void Savegame_Legacy_ReadArm(LARA_ARM *arm)
 {
     int32_t frame_base;
-    SaveGame_Legacy_Read(&frame_base, sizeof(int32_t));
+    Savegame_Legacy_Read(&frame_base, sizeof(int32_t));
     arm->frame_base = (int16_t *)((size_t)g_AnimFrames + (size_t)frame_base);
 
-    SaveGame_Legacy_Read(&arm->frame_number, sizeof(int16_t));
-    SaveGame_Legacy_Read(&arm->lock, sizeof(int16_t));
-    SaveGame_Legacy_Read(&arm->y_rot, sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Read(&arm->x_rot, sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Read(&arm->z_rot, sizeof(PHD_ANGLE));
-    SaveGame_Legacy_Read(&arm->flash_gun, sizeof(int16_t));
+    Savegame_Legacy_Read(&arm->frame_number, sizeof(int16_t));
+    Savegame_Legacy_Read(&arm->lock, sizeof(int16_t));
+    Savegame_Legacy_Read(&arm->y_rot, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Read(&arm->x_rot, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Read(&arm->z_rot, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Read(&arm->flash_gun, sizeof(int16_t));
 }
 
-static void SaveGame_Legacy_ReadLOT(LOT_INFO *lot)
+static void Savegame_Legacy_ReadLOT(LOT_INFO *lot)
 {
     lot->node = NULL;
-    SaveGame_Legacy_Skip(sizeof(BOX_NODE *));
+    Savegame_Legacy_Skip(sizeof(BOX_NODE *));
 
-    SaveGame_Legacy_Read(&lot->head, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lot->tail, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lot->search_number, sizeof(uint16_t));
-    SaveGame_Legacy_Read(&lot->block_mask, sizeof(uint16_t));
-    SaveGame_Legacy_Read(&lot->step, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lot->drop, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lot->fly, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lot->zone_count, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lot->target_box, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lot->required_box, sizeof(int16_t));
-    SaveGame_Legacy_Read(&lot->target, sizeof(PHD_VECTOR));
+    Savegame_Legacy_Read(&lot->head, sizeof(int16_t));
+    Savegame_Legacy_Read(&lot->tail, sizeof(int16_t));
+    Savegame_Legacy_Read(&lot->search_number, sizeof(uint16_t));
+    Savegame_Legacy_Read(&lot->block_mask, sizeof(uint16_t));
+    Savegame_Legacy_Read(&lot->step, sizeof(int16_t));
+    Savegame_Legacy_Read(&lot->drop, sizeof(int16_t));
+    Savegame_Legacy_Read(&lot->fly, sizeof(int16_t));
+    Savegame_Legacy_Read(&lot->zone_count, sizeof(int16_t));
+    Savegame_Legacy_Read(&lot->target_box, sizeof(int16_t));
+    Savegame_Legacy_Read(&lot->required_box, sizeof(int16_t));
+    Savegame_Legacy_Read(&lot->target, sizeof(PHD_VECTOR));
 }
 
-char *SaveGame_Legacy_GetSaveFileName(int32_t slot)
+char *Savegame_Legacy_GetSaveFileName(int32_t slot)
 {
     size_t out_size =
         snprintf(NULL, 0, g_GameFlow.savegame_fmt_legacy, slot) + 1;
@@ -360,7 +360,7 @@ char *SaveGame_Legacy_GetSaveFileName(int32_t slot)
     return out;
 }
 
-bool SaveGame_Legacy_FillInfo(MYFILE *fp, SAVEGAME_INFO *info)
+bool Savegame_Legacy_FillInfo(MYFILE *fp, SAVEGAME_INFO *info)
 {
     File_Seek(fp, 0, SEEK_SET);
 
@@ -395,7 +395,7 @@ bool SaveGame_Legacy_FillInfo(MYFILE *fp, SAVEGAME_INFO *info)
     return true;
 }
 
-bool SaveGame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
+bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
 {
     assert(game_info);
 
@@ -407,45 +407,45 @@ bool SaveGame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     File_Seek(fp, 0, FILE_SEEK_SET);
     File_Read(buffer, sizeof(char), File_Size(fp), fp);
 
-    bool skip_reading_evil_lara = SaveGame_Legacy_NeedsEvilLaraFix(buffer);
+    bool skip_reading_evil_lara = Savegame_Legacy_NeedsEvilLaraFix(buffer);
     if (skip_reading_evil_lara) {
         LOG_INFO("Enabling Evil Lara savegame fix");
     }
 
-    SaveGame_Legacy_Reset(buffer);
-    SaveGame_Legacy_Skip(SAVEGAME_LEGACY_TITLE_SIZE); // level title
-    SaveGame_Legacy_Skip(sizeof(int32_t)); // save counter
+    Savegame_Legacy_Reset(buffer);
+    Savegame_Legacy_Skip(SAVEGAME_LEGACY_TITLE_SIZE); // level title
+    Savegame_Legacy_Skip(sizeof(int32_t)); // save counter
 
     assert(game_info->start);
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         START_INFO *start = &game_info->start[i];
-        SaveGame_Legacy_Read(&start->pistol_ammo, sizeof(uint16_t));
-        SaveGame_Legacy_Read(&start->magnum_ammo, sizeof(uint16_t));
-        SaveGame_Legacy_Read(&start->uzi_ammo, sizeof(uint16_t));
-        SaveGame_Legacy_Read(&start->shotgun_ammo, sizeof(uint16_t));
-        SaveGame_Legacy_Read(&start->num_medis, sizeof(uint8_t));
-        SaveGame_Legacy_Read(&start->num_big_medis, sizeof(uint8_t));
-        SaveGame_Legacy_Read(&start->num_scions, sizeof(uint8_t));
-        SaveGame_Legacy_Read(&start->gun_status, sizeof(int8_t));
-        SaveGame_Legacy_Read(&start->gun_type, sizeof(int8_t));
-        SaveGame_Legacy_Read(&start->flags, sizeof(uint16_t));
+        Savegame_Legacy_Read(&start->pistol_ammo, sizeof(uint16_t));
+        Savegame_Legacy_Read(&start->magnum_ammo, sizeof(uint16_t));
+        Savegame_Legacy_Read(&start->uzi_ammo, sizeof(uint16_t));
+        Savegame_Legacy_Read(&start->shotgun_ammo, sizeof(uint16_t));
+        Savegame_Legacy_Read(&start->num_medis, sizeof(uint8_t));
+        Savegame_Legacy_Read(&start->num_big_medis, sizeof(uint8_t));
+        Savegame_Legacy_Read(&start->num_scions, sizeof(uint8_t));
+        Savegame_Legacy_Read(&start->gun_status, sizeof(int8_t));
+        Savegame_Legacy_Read(&start->gun_type, sizeof(int8_t));
+        Savegame_Legacy_Read(&start->flags, sizeof(uint16_t));
     }
 
-    SaveGame_Legacy_Read(&game_info->stats.timer, sizeof(uint32_t));
-    SaveGame_Legacy_Read(&game_info->stats.kill_count, sizeof(uint32_t));
-    SaveGame_Legacy_Read(&game_info->stats.secret_flags, sizeof(uint16_t));
-    SaveGame_Legacy_Read(&g_CurrentLevel, sizeof(uint16_t));
-    SaveGame_Legacy_Read(&game_info->stats.pickup_count, sizeof(uint8_t));
-    SaveGame_Legacy_Read(&game_info->bonus_flag, sizeof(uint8_t));
+    Savegame_Legacy_Read(&game_info->stats.timer, sizeof(uint32_t));
+    Savegame_Legacy_Read(&game_info->stats.kill_count, sizeof(uint32_t));
+    Savegame_Legacy_Read(&game_info->stats.secret_flags, sizeof(uint16_t));
+    Savegame_Legacy_Read(&g_CurrentLevel, sizeof(uint16_t));
+    Savegame_Legacy_Read(&game_info->stats.pickup_count, sizeof(uint8_t));
+    Savegame_Legacy_Read(&game_info->bonus_flag, sizeof(uint8_t));
 
     for (int i = 0; i < g_GameFlow.level_count; i++) {
-        ResetEndInfo(i);
+        Savegame_ResetEndInfo(i);
     }
     game_info->end[g_CurrentLevel].stats = game_info->stats;
 
     InitialiseLaraInventory(g_CurrentLevel);
     SAVEGAME_LEGACY_ITEM_STATS item_stats = { 0 };
-    SaveGame_Legacy_Read(&item_stats, sizeof(item_stats));
+    Savegame_Legacy_Read(&item_stats, sizeof(item_stats));
     Inv_AddItemNTimes(O_PICKUP_ITEM1, item_stats.num_pickup1);
     Inv_AddItemNTimes(O_PICKUP_ITEM2, item_stats.num_pickup2);
     Inv_AddItemNTimes(O_PUZZLE_ITEM1, item_stats.num_puzzle1);
@@ -458,18 +458,18 @@ bool SaveGame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     Inv_AddItemNTimes(O_KEY_ITEM4, item_stats.num_key4);
     Inv_AddItemNTimes(O_LEADBAR_ITEM, item_stats.num_leadbar);
 
-    SaveGame_Legacy_Read(&tmp32, sizeof(int32_t));
+    Savegame_Legacy_Read(&tmp32, sizeof(int32_t));
     if (tmp32) {
         FlipMap();
     }
 
     for (int i = 0; i < MAX_FLIP_MAPS; i++) {
-        SaveGame_Legacy_Read(&tmp8, sizeof(int8_t));
+        Savegame_Legacy_Read(&tmp8, sizeof(int8_t));
         g_FlipMapTable[i] = tmp8 << 8;
     }
 
     for (int i = 0; i < g_NumberCameras; i++) {
-        SaveGame_Legacy_Read(&g_Camera.fixed[i].flags, sizeof(int16_t));
+        Savegame_Legacy_Read(&g_Camera.fixed[i].flags, sizeof(int16_t));
     }
 
     for (int i = 0; i < g_LevelItemCount; i++) {
@@ -477,10 +477,10 @@ bool SaveGame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         OBJECT_INFO *obj = &g_Objects[item->object_number];
 
         if (obj->save_position) {
-            SaveGame_Legacy_Read(&item->pos, sizeof(PHD_3DPOS));
-            SaveGame_Legacy_Read(&tmp16, sizeof(int16_t));
-            SaveGame_Legacy_Read(&item->speed, sizeof(int16_t));
-            SaveGame_Legacy_Read(&item->fall_speed, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->pos, sizeof(PHD_3DPOS));
+            Savegame_Legacy_Read(&tmp16, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->speed, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->fall_speed, sizeof(int16_t));
 
             if (item->room_number != tmp16) {
                 ItemNewRoom(i, tmp16);
@@ -488,22 +488,22 @@ bool SaveGame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         }
 
         if (obj->save_anim) {
-            SaveGame_Legacy_Read(&item->current_anim_state, sizeof(int16_t));
-            SaveGame_Legacy_Read(&item->goal_anim_state, sizeof(int16_t));
-            SaveGame_Legacy_Read(&item->required_anim_state, sizeof(int16_t));
-            SaveGame_Legacy_Read(&item->anim_number, sizeof(int16_t));
-            SaveGame_Legacy_Read(&item->frame_number, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->current_anim_state, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->goal_anim_state, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->required_anim_state, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->anim_number, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->frame_number, sizeof(int16_t));
         }
 
         if (obj->save_hitpoints) {
-            SaveGame_Legacy_Read(&item->hit_points, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->hit_points, sizeof(int16_t));
         }
 
         if (obj->save_flags
             && (item->object_number != O_EVIL_LARA
                 || !skip_reading_evil_lara)) {
-            SaveGame_Legacy_Read(&item->flags, sizeof(int16_t));
-            SaveGame_Legacy_Read(&item->timer, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->flags, sizeof(int16_t));
+            Savegame_Legacy_Read(&item->timer, sizeof(int16_t));
 
             if (item->flags & IF_KILLED_ITEM) {
                 KillItem(i);
@@ -525,16 +525,16 @@ bool SaveGame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
                 EnableBaddieAI(i, 1);
                 CREATURE_INFO *creature = item->data;
                 if (creature) {
-                    SaveGame_Legacy_Read(
+                    Savegame_Legacy_Read(
                         &creature->head_rotation, sizeof(int16_t));
-                    SaveGame_Legacy_Read(
+                    Savegame_Legacy_Read(
                         &creature->neck_rotation, sizeof(int16_t));
-                    SaveGame_Legacy_Read(
+                    Savegame_Legacy_Read(
                         &creature->maximum_turn, sizeof(int16_t));
-                    SaveGame_Legacy_Read(&creature->flags, sizeof(int16_t));
-                    SaveGame_Legacy_Read(&creature->mood, sizeof(int32_t));
+                    Savegame_Legacy_Read(&creature->flags, sizeof(int16_t));
+                    Savegame_Legacy_Read(&creature->mood, sizeof(int32_t));
                 } else {
-                    SaveGame_Legacy_Skip(4 * 2 + 4);
+                    Savegame_Legacy_Skip(4 * 2 + 4);
                 }
             } else if (obj->intelligent) {
                 item->data = NULL;
@@ -542,49 +542,49 @@ bool SaveGame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         }
     }
 
-    SaveGame_Legacy_ReadLara(&g_Lara);
-    SaveGame_Legacy_Read(&g_FlipEffect, sizeof(int32_t));
-    SaveGame_Legacy_Read(&g_FlipTimer, sizeof(int32_t));
+    Savegame_Legacy_ReadLara(&g_Lara);
+    Savegame_Legacy_Read(&g_FlipEffect, sizeof(int32_t));
+    Savegame_Legacy_Read(&g_FlipTimer, sizeof(int32_t));
     Memory_FreePointer(&buffer);
     return true;
 }
 
-void SaveGame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
+void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
 {
     assert(game_info);
 
     char *buffer = Memory_Alloc(SAVEGAME_LEGACY_MAX_BUFFER_SIZE);
-    SaveGame_Legacy_Reset(buffer);
+    Savegame_Legacy_Reset(buffer);
     memset(m_SGBufPtr, 0, SAVEGAME_LEGACY_MAX_BUFFER_SIZE);
 
     char title[SAVEGAME_LEGACY_TITLE_SIZE];
     snprintf(
         title, SAVEGAME_LEGACY_TITLE_SIZE, "%s",
         g_GameFlow.levels[g_CurrentLevel].level_title);
-    SaveGame_Legacy_Write(title, SAVEGAME_LEGACY_TITLE_SIZE);
-    SaveGame_Legacy_Write(&g_SaveCounter, sizeof(int32_t));
+    Savegame_Legacy_Write(title, SAVEGAME_LEGACY_TITLE_SIZE);
+    Savegame_Legacy_Write(&g_SaveCounter, sizeof(int32_t));
 
     assert(game_info->start);
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         START_INFO *start = &game_info->start[i];
-        SaveGame_Legacy_Write(&start->pistol_ammo, sizeof(uint16_t));
-        SaveGame_Legacy_Write(&start->magnum_ammo, sizeof(uint16_t));
-        SaveGame_Legacy_Write(&start->uzi_ammo, sizeof(uint16_t));
-        SaveGame_Legacy_Write(&start->shotgun_ammo, sizeof(uint16_t));
-        SaveGame_Legacy_Write(&start->num_medis, sizeof(uint8_t));
-        SaveGame_Legacy_Write(&start->num_big_medis, sizeof(uint8_t));
-        SaveGame_Legacy_Write(&start->num_scions, sizeof(uint8_t));
-        SaveGame_Legacy_Write(&start->gun_status, sizeof(int8_t));
-        SaveGame_Legacy_Write(&start->gun_type, sizeof(int8_t));
-        SaveGame_Legacy_Write(&start->flags, sizeof(uint16_t));
+        Savegame_Legacy_Write(&start->pistol_ammo, sizeof(uint16_t));
+        Savegame_Legacy_Write(&start->magnum_ammo, sizeof(uint16_t));
+        Savegame_Legacy_Write(&start->uzi_ammo, sizeof(uint16_t));
+        Savegame_Legacy_Write(&start->shotgun_ammo, sizeof(uint16_t));
+        Savegame_Legacy_Write(&start->num_medis, sizeof(uint8_t));
+        Savegame_Legacy_Write(&start->num_big_medis, sizeof(uint8_t));
+        Savegame_Legacy_Write(&start->num_scions, sizeof(uint8_t));
+        Savegame_Legacy_Write(&start->gun_status, sizeof(int8_t));
+        Savegame_Legacy_Write(&start->gun_type, sizeof(int8_t));
+        Savegame_Legacy_Write(&start->flags, sizeof(uint16_t));
     }
 
-    SaveGame_Legacy_Write(&game_info->stats.timer, sizeof(uint32_t));
-    SaveGame_Legacy_Write(&game_info->stats.kill_count, sizeof(uint32_t));
-    SaveGame_Legacy_Write(&game_info->stats.secret_flags, sizeof(uint16_t));
-    SaveGame_Legacy_Write(&g_CurrentLevel, sizeof(uint16_t));
-    SaveGame_Legacy_Write(&game_info->stats.pickup_count, sizeof(uint8_t));
-    SaveGame_Legacy_Write(&game_info->bonus_flag, sizeof(uint8_t));
+    Savegame_Legacy_Write(&game_info->stats.timer, sizeof(uint32_t));
+    Savegame_Legacy_Write(&game_info->stats.kill_count, sizeof(uint32_t));
+    Savegame_Legacy_Write(&game_info->stats.secret_flags, sizeof(uint16_t));
+    Savegame_Legacy_Write(&g_CurrentLevel, sizeof(uint16_t));
+    Savegame_Legacy_Write(&game_info->stats.pickup_count, sizeof(uint8_t));
+    Savegame_Legacy_Write(&game_info->bonus_flag, sizeof(uint8_t));
 
     SAVEGAME_LEGACY_ITEM_STATS item_stats = {
         .num_pickup1 = Inv_RequestItem(O_PICKUP_ITEM1),
@@ -601,16 +601,16 @@ void SaveGame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
         0
     };
 
-    SaveGame_Legacy_Write(&item_stats, sizeof(item_stats));
+    Savegame_Legacy_Write(&item_stats, sizeof(item_stats));
 
-    SaveGame_Legacy_Write(&g_FlipStatus, sizeof(int32_t));
+    Savegame_Legacy_Write(&g_FlipStatus, sizeof(int32_t));
     for (int i = 0; i < MAX_FLIP_MAPS; i++) {
         int8_t flag = g_FlipMapTable[i] >> 8;
-        SaveGame_Legacy_Write(&flag, sizeof(int8_t));
+        Savegame_Legacy_Write(&flag, sizeof(int8_t));
     }
 
     for (int i = 0; i < g_NumberCameras; i++) {
-        SaveGame_Legacy_Write(&g_Camera.fixed[i].flags, sizeof(int16_t));
+        Savegame_Legacy_Write(&g_Camera.fixed[i].flags, sizeof(int16_t));
     }
 
     for (int i = 0; i < g_LevelItemCount; i++) {
@@ -618,22 +618,22 @@ void SaveGame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
         OBJECT_INFO *obj = &g_Objects[item->object_number];
 
         if (obj->save_position) {
-            SaveGame_Legacy_Write(&item->pos, sizeof(PHD_3DPOS));
-            SaveGame_Legacy_Write(&item->room_number, sizeof(int16_t));
-            SaveGame_Legacy_Write(&item->speed, sizeof(int16_t));
-            SaveGame_Legacy_Write(&item->fall_speed, sizeof(int16_t));
+            Savegame_Legacy_Write(&item->pos, sizeof(PHD_3DPOS));
+            Savegame_Legacy_Write(&item->room_number, sizeof(int16_t));
+            Savegame_Legacy_Write(&item->speed, sizeof(int16_t));
+            Savegame_Legacy_Write(&item->fall_speed, sizeof(int16_t));
         }
 
         if (obj->save_anim) {
-            SaveGame_Legacy_Write(&item->current_anim_state, sizeof(int16_t));
-            SaveGame_Legacy_Write(&item->goal_anim_state, sizeof(int16_t));
-            SaveGame_Legacy_Write(&item->required_anim_state, sizeof(int16_t));
-            SaveGame_Legacy_Write(&item->anim_number, sizeof(int16_t));
-            SaveGame_Legacy_Write(&item->frame_number, sizeof(int16_t));
+            Savegame_Legacy_Write(&item->current_anim_state, sizeof(int16_t));
+            Savegame_Legacy_Write(&item->goal_anim_state, sizeof(int16_t));
+            Savegame_Legacy_Write(&item->required_anim_state, sizeof(int16_t));
+            Savegame_Legacy_Write(&item->anim_number, sizeof(int16_t));
+            Savegame_Legacy_Write(&item->frame_number, sizeof(int16_t));
         }
 
         if (obj->save_hitpoints) {
-            SaveGame_Legacy_Write(&item->hit_points, sizeof(int16_t));
+            Savegame_Legacy_Write(&item->hit_points, sizeof(int16_t));
         }
 
         if (obj->save_flags) {
@@ -642,25 +642,25 @@ void SaveGame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
             if (obj->intelligent && item->data) {
                 flags |= SAVE_CREATURE;
             }
-            SaveGame_Legacy_Write(&flags, sizeof(uint16_t));
-            SaveGame_Legacy_Write(&item->timer, sizeof(int16_t));
+            Savegame_Legacy_Write(&flags, sizeof(uint16_t));
+            Savegame_Legacy_Write(&item->timer, sizeof(int16_t));
             if (flags & SAVE_CREATURE) {
                 CREATURE_INFO *creature = item->data;
-                SaveGame_Legacy_Write(
+                Savegame_Legacy_Write(
                     &creature->head_rotation, sizeof(int16_t));
-                SaveGame_Legacy_Write(
+                Savegame_Legacy_Write(
                     &creature->neck_rotation, sizeof(int16_t));
-                SaveGame_Legacy_Write(&creature->maximum_turn, sizeof(int16_t));
-                SaveGame_Legacy_Write(&creature->flags, sizeof(int16_t));
-                SaveGame_Legacy_Write(&creature->mood, sizeof(int32_t));
+                Savegame_Legacy_Write(&creature->maximum_turn, sizeof(int16_t));
+                Savegame_Legacy_Write(&creature->flags, sizeof(int16_t));
+                Savegame_Legacy_Write(&creature->mood, sizeof(int32_t));
             }
         }
     }
 
-    SaveGame_Legacy_WriteLara(&g_Lara);
+    Savegame_Legacy_WriteLara(&g_Lara);
 
-    SaveGame_Legacy_Write(&g_FlipEffect, sizeof(int32_t));
-    SaveGame_Legacy_Write(&g_FlipTimer, sizeof(int32_t));
+    Savegame_Legacy_Write(&g_FlipEffect, sizeof(int32_t));
+    Savegame_Legacy_Write(&g_FlipTimer, sizeof(int32_t));
 
     File_Write(buffer, sizeof(char), m_SGBufPos, fp);
     Memory_FreePointer(&buffer);

--- a/src/game/savegame_legacy.h
+++ b/src/game/savegame_legacy.h
@@ -8,7 +8,7 @@
 
 // TombATI implementation of savegames.
 
-char *SaveGame_Legacy_GetSaveFileName(int32_t slot);
-bool SaveGame_Legacy_FillInfo(MYFILE *fp, SAVEGAME_INFO *info);
-bool SaveGame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info);
-void SaveGame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info);
+char *Savegame_Legacy_GetSaveFileName(int32_t slot);
+bool Savegame_Legacy_FillInfo(MYFILE *fp, SAVEGAME_INFO *info);
+bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info);
+void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info);

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -287,7 +287,7 @@ void ObjectObjects()
     SetupScionHolder(&g_Objects[O_SCION_HOLDER]);
 
     SetupLeadBar(&g_Objects[O_LEADBAR_ITEM]);
-    SetupSaveGameCrystal(&g_Objects[O_SAVEGAME_ITEM]);
+    SetupSavegameCrystal(&g_Objects[O_SAVEGAME_ITEM]);
     SetupKeyHole(&g_Objects[O_KEY_HOLE1]);
     SetupKeyHole(&g_Objects[O_KEY_HOLE2]);
     SetupKeyHole(&g_Objects[O_KEY_HOLE3]);

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -155,10 +155,10 @@ void InitialiseGameFlags()
 
 void InitialiseLevelFlags()
 {
-    g_GameInfo.secrets = 0;
-    g_GameInfo.timer = 0;
-    g_GameInfo.pickups = 0;
-    g_GameInfo.kills = 0;
+    g_GameInfo.stats.timer = 0;
+    g_GameInfo.stats.secret_flags = 0;
+    g_GameInfo.stats.pickup_count = 0;
+    g_GameInfo.stats.kill_count = 0;
 }
 
 void BaddyObjects()

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -153,8 +153,8 @@ void Shell_Main()
         return;
     }
 
-    InitialiseStartInfo();
-    SaveGame_ScanSavedGames();
+    Savegame_InitStartEndInfo();
+    Savegame_ScanSavedGames();
     Settings_Read();
 
     Screen_ApplyResolution();
@@ -174,7 +174,7 @@ void Shell_Main()
             break;
 
         case GF_START_SAVED_GAME: {
-            int16_t level_num = SaveGame_GetLevelNumber(gf_param);
+            int16_t level_num = Savegame_GetLevelNumber(gf_param);
             if (level_num < 0) {
                 LOG_ERROR("Corrupt save file!");
                 gf_option = GF_EXIT_TO_TITLE;
@@ -194,7 +194,7 @@ void Shell_Main()
             break;
 
         case GF_LEVEL_COMPLETE:
-            gf_option = LevelCompleteSequence(gf_param);
+            gf_option = GF_EXIT_TO_TITLE;
             break;
 
         case GF_EXIT_TO_TITLE:

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -258,6 +258,8 @@ void Stats_Show(int32_t level_num)
     char time_str[100];
     TEXTSTRING *txt;
 
+    const GAME_STATS *stats = &g_GameInfo.end[level_num].stats;
+
     Text_RemoveAll();
 
     // heading
@@ -267,7 +269,7 @@ void Stats_Show(int32_t level_num)
     Text_CentreV(txt, 1);
 
     // time taken
-    int32_t seconds = g_GameInfo.timer / 30;
+    int32_t seconds = stats->timer / 30;
     int32_t hours = seconds / 3600;
     int32_t minutes = (seconds / 60) % 60;
     seconds %= 60;
@@ -284,34 +286,33 @@ void Stats_Show(int32_t level_num)
     Text_CentreV(txt, 1);
 
     // secrets
-    int32_t secrets_taken = 0;
-    int32_t secrets_total = MAX_SECRETS;
-    do {
-        if (g_GameInfo.secrets & 1) {
-            secrets_taken++;
+    int32_t secret_count = 0;
+    int16_t secret_flags = stats->secret_flags;
+    for (int i = 0; i < MAX_SECRETS; i++) {
+        if (secret_flags & 1) {
+            secret_count++;
         }
-        g_GameInfo.secrets >>= 1;
-        secrets_total--;
-    } while (secrets_total);
+        secret_flags >>= 1;
+    }
     sprintf(
-        string, g_GameFlow.strings[GS_STATS_SECRETS_FMT], secrets_taken,
-        g_GameFlow.levels[level_num].secrets);
+        string, g_GameFlow.strings[GS_STATS_SECRETS_FMT], secret_count,
+        stats->max_secret_count);
     txt = Text_Create(0, 40, string);
     Text_CentreH(txt, 1);
     Text_CentreV(txt, 1);
 
     // pickups
     sprintf(
-        string, g_GameFlow.strings[GS_STATS_PICKUPS_FMT], g_GameInfo.pickups,
-        g_GameFlow.levels[level_num].pickups);
+        string, g_GameFlow.strings[GS_STATS_PICKUPS_FMT], stats->pickup_count,
+        stats->max_pickup_count);
     txt = Text_Create(0, 10, string);
     Text_CentreH(txt, 1);
     Text_CentreV(txt, 1);
 
     // kills
     sprintf(
-        string, g_GameFlow.strings[GS_STATS_KILLS_FMT], g_GameInfo.kills,
-        g_GameFlow.levels[level_num].kills);
+        string, g_GameFlow.strings[GS_STATS_KILLS_FMT], stats->kill_count,
+        stats->max_kill_count);
     txt = Text_Create(0, -20, string);
     Text_CentreH(txt, 1);
     Text_CentreV(txt, 1);
@@ -337,14 +338,4 @@ void Stats_Show(int32_t level_num)
     }
 
     Output_FadeReset();
-
-    if (level_num == g_GameFlow.last_level_num) {
-        g_GameInfo.bonus_flag = GBF_NGPLUS;
-    } else {
-        CreateStartInfo(level_num + 1);
-        ModifyStartInfo(level_num + 1);
-    }
-
-    g_GameInfo.start[g_CurrentLevel].flags.available = 0;
-    Screen_ApplyResolution();
 }

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1447,6 +1447,16 @@ typedef struct LARA_INFO {
     LOT_INFO LOT;
 } LARA_INFO;
 
+typedef struct GAME_STATS {
+    uint32_t timer;
+    uint32_t kill_count;
+    uint16_t secret_flags;
+    uint8_t pickup_count;
+    uint32_t max_kill_count;
+    uint16_t max_secret_count;
+    uint8_t max_pickup_count;
+} GAME_STATS;
+
 typedef struct START_INFO {
     int32_t lara_hitpoints;
     uint16_t pistol_ammo;
@@ -1471,12 +1481,14 @@ typedef struct START_INFO {
     } flags;
 } START_INFO;
 
+typedef struct END_INFO {
+    GAME_STATS stats;
+} END_INFO;
+
 typedef struct GAME_INFO {
     START_INFO *start;
-    uint32_t timer;
-    uint32_t kills;
-    uint16_t secrets;
-    uint8_t pickups;
+    END_INFO *end;
+    GAME_STATS stats; // always for current level
     uint8_t bonus_flag;
     int32_t save_slot_to_load;
 } GAME_INFO;

--- a/src/global/vars.h
+++ b/src/global/vars.h
@@ -120,7 +120,7 @@ extern int32_t g_SpriteInfoCount;
 extern int32_t g_SpriteCount;
 extern int32_t g_OverlapCount;
 
-extern REQUEST_INFO g_LoadSaveGameRequester;
+extern REQUEST_INFO g_LoadSavegameRequester;
 
 extern int16_t g_StoredLaraHealth;
 

--- a/src/specific/s_shell.c
+++ b/src/specific/s_shell.c
@@ -38,7 +38,7 @@ void S_Shell_Shutdown()
     GameBuf_Shutdown();
     Output_Shutdown();
     S_Audio_Shutdown();
-    SaveGame_Shutdown();
+    Savegame_Shutdown();
 }
 
 void S_Shell_SeedRandom()


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes

#### Descripton

Resolves #336.

It changes the BSON format in an incompatible way, so BSON saves made on the current master will cease to work.

#### Testing

Make the following change to the gameflow:

```diff
diff --git a/bin/cfg/Tomb1Main_gameflow.json5 b/bin/cfg/Tomb1Main_gameflow.json5
index 541304a3..e1458f7d 100644
--- a/bin/cfg/Tomb1Main_gameflow.json5
+++ b/bin/cfg/Tomb1Main_gameflow.json5
@@ -104,6 +104,7 @@
                 {"type": "start_game"},
                 {"type": "loop_game"},
                 {"type": "stop_game"},
+                {"type": "level_stats", "level_id": 1},
                 {"type": "level_stats", "level_id": 2},
                 {"type": "exit_to_level", "level_id": 3},
             ],
```

this will display stats for both level 1 and level 2 at the end of level 2.

- [x] Start the game. Pick up an item. Finish the level. It should show 1 out of 7 pickups.
- [x] Start the game. Pick up an item. Finish the level. Kill 2 wolves. Finish the level. It should show 1 out of 7 pickups for Caves and then 2 out of 29 kills for Vilca.
- [ ] Start the game. Pick up an item. Save the game using the new format. Load the game. Finish the level. It should show 1 out of 7 pickups.
- [ ] Start the game. Pick up an item. Save the game using the new format. Load the game. Finish the level. Kill 2 wolves. Finish the level. It should show 1 out of 7 pickups for Caves and then 2 out of 29 kills for Vilca.
- [ ] Start the game. Pick up an item. Finish the level. Save the game using the new format. Load the game. Kill 2 wolves. Finish the level. It should show 1 out of 7 pickups for Caves and then 2 out of 29 kills for Vilca.
- [ ] Start the game. Pick up an item. Finish the level. Kill 2 wolves. Save the game using the new format. Load the game. Finish the level. It should show 1 out of 7 pickups for Caves and then 2 out of 29 kills for Vilca.
- [x] Start the game. Pick up an item. Save the game using the legacy format. Load the game. Finish the level. It should show 1 out of 7 pickups.
- [x] Start the game. Pick up an item. Save the game using the legacy format. Load the game. Finish the level. Kill 2 wolves. Finish the level. It should show whatever for Caves and then 2 out of 29 kills for Vilca.
- [x] Start the game. Pick up an item. Finish the level. Save the game using the legacy format. Load the game. Kill 2 wolves. Finish the level. It should show whatever for Caves and then 2 out of 29 kills for Vilca.
- [x] Start the game. Pick up an item. Finish the level. Kill 2 wolves. Save the game using the legacy format. Load the game. Finish the level. It should show whatever for Caves and then 2 out of 29 kills for Vilca.

TLDR: historic levels should always work in the BSON format, they may not work for legacy saves. Current level should *always* work. Pay attention to the max counts.

In order to save and load legacy saves we need to change `allow_load` and `allow_save` members in `savegame.c`.
