### PR TITLE
sound: fix rare audio glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed glitched floor in the Natla cutscene
 - fixed gun pickups disappearing in rare circumstances on save load (#406)
 - fixed empty mutant shells in Unfinished Business spawning Lara's hips (#250)
+- fixed rare audio distance glitch (#421)
 
 ## [2.5](https://github.com/rr-/Tomb1Main/compare/2.4...2.5) - 2022-01-31
 - added CHANGELOG.md

--- a/src/game/sound.c
+++ b/src/game/sound.c
@@ -373,6 +373,8 @@ bool Sound_Effect(int32_t sfx_num, PHD_3DPOS *pos, uint32_t flags)
             fxslot->sound_id = S_Audio_SampleSoundPlay(
                 sfx_id, Sound_ConvertVolumeToDecibel(volume),
                 Sound_CalcPitch(pitch), Sound_ConvertPanToDecibel(pan), false);
+
+            Sound_ClearSlotHandles(fxslot);
             return true;
         }
         fxslot->sound_id = S_Audio_SampleSoundPlay(

--- a/src/game/sound.c
+++ b/src/game/sound.c
@@ -18,10 +18,9 @@
 #define SOUND_FLIPFLAG 0x40
 #define SOUND_UNFLIPFLAG 0x80
 #define SOUND_RANGE 8
-#define SOUND_RADIUS (SOUND_RANGE << 10)
-#define SOUND_MAX_VOLUME 0x7FFF
-#define SOUND_RANGE_MULT_CONSTANT                                              \
-    ((int32_t)((SOUND_MAX_VOLUME + 1) / SOUND_RADIUS))
+#define SOUND_RANGE_MULT_CONSTANT 4
+#define SOUND_RADIUS (SOUND_RANGE * WALL_L)
+#define SOUND_MAX_VOLUME ((SOUND_RADIUS * SOUND_RANGE_MULT_CONSTANT) - 1)
 #define SOUND_MAX_VOLUME_CHANGE 0x2000
 #define SOUND_MAX_PITCH_CHANGE 10
 #define SOUND_NOT_AUDIBLE -1
@@ -65,7 +64,9 @@ static void Sound_ClearSlotHandles(SOUND_SLOT *slot);
 
 static int32_t Sound_ConvertVolumeToDecibel(int volume)
 {
-    return m_DecibelLUT[(volume & SOUND_MAX_VOLUME) >> 6];
+    return m_DecibelLUT
+        [(volume & SOUND_MAX_VOLUME) * DECIBEL_LUT_SIZE
+         / (SOUND_MAX_VOLUME + 1)];
 }
 
 static int32_t Sound_ConvertPanToDecibel(uint16_t pan)
@@ -322,7 +323,7 @@ bool Sound_Effect(int32_t sfx_num, PHD_3DPOS *pos, uint32_t flags)
 
     int32_t pitch = 100;
     if (s->flags & SAMPLE_FLAG_PITCH_WIBBLE) {
-        pitch += ((Random_GetDraw() * SOUND_MAX_PITCH_CHANGE) / 16384)
+        pitch += ((Random_GetDraw() * SOUND_MAX_PITCH_CHANGE) / 0x4000)
             - SOUND_MAX_PITCH_CHANGE;
     }
 

--- a/src/game/sound.c
+++ b/src/game/sound.c
@@ -65,7 +65,7 @@ static void Sound_ClearSlotHandles(SOUND_SLOT *slot);
 
 static int32_t Sound_ConvertVolumeToDecibel(int volume)
 {
-    return m_DecibelLUT[(volume & 0x7FFF) >> 6];
+    return m_DecibelLUT[(volume & SOUND_MAX_VOLUME) >> 6];
 }
 
 static int32_t Sound_ConvertPanToDecibel(uint16_t pan)
@@ -142,9 +142,7 @@ static void Sound_UpdateSlotParams(SOUND_SLOT *slot)
         return;
     }
 
-    if (volume > 0x7FFF) {
-        volume = 0x7FFF;
-    }
+    CLAMPG(volume, SOUND_MAX_VOLUME);
 
     slot->volume = volume;
 
@@ -334,9 +332,7 @@ bool Sound_Effect(int32_t sfx_num, PHD_3DPOS *pos, uint32_t flags)
         sfx_id += (Random_GetDraw() * vars) / 0x8000;
     }
 
-    if (volume > SOUND_MAX_VOLUME) {
-        volume = SOUND_MAX_VOLUME;
-    }
+    CLAMPG(volume, SOUND_MAX_VOLUME);
 
     volume = (m_MasterVolume * volume) >> 6;
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes

#### Descripton

Resolves #421. Tested heavily on ×5 speed. The scenario I described in #421 was indeed the problem – we just missed one call to the slot deduplication.