### PR TITLE
pod: fix pods unhatching on reload if user saves during explosion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added ability to automatically walk to pickups when nearby (#18)
 - added ability to automatically walk to switches when nearby (#222)
 - added ability to turn off detailed end of the level stats (#447)
+- fixed exploded mutant pods sometimes appearing unhatched on reload (#423)
 
 ## [2.6.4](https://github.com/rr-/Tomb1Main/compare/2.6.3...2.6.4) - 2022-02-20
 - fixed crash when loading a legacy save and saving on a new slot (#442, regression from 2.6)

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Not all options are turned on by default. Refer to `Tomb1Main.json5` for details
 - fixed empty mutant shells in Unfinished Business spawning Lara's hips
 - fixed gun pickups disappearing in rare circumstances on save load (#406)
 - fixed broken dart ricochet effect
+- fixed exploded mutant pods sometimes appearing unhatched on reload
 
 ## Showcase
 

--- a/src/game/ai/pod.c
+++ b/src/game/ai/pod.c
@@ -117,6 +117,7 @@ void PodControl(int16_t item_num)
                     bug->status = IS_INVISIBLE;
                 }
             }
+            item->status = IS_DEACTIVATED;
         }
     }
 


### PR DESCRIPTION
Resolves #423.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes

#### Descripton

...
