### PR TITLE
option_passport: add contextual arrows and clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added ability to automatically walk to switches when nearby (#222)
 - added ability to turn off detailed end of the level stats (#447)
 - fixed exploded mutant pods sometimes appearing unhatched on reload (#423)
+- added contextual arrows to passport navigation (#420)
 
 ## [2.6.4](https://github.com/rr-/Tomb1Main/compare/2.6.3...2.6.4) - 2022-02-20
 - fixed crash when loading a legacy save and saving on a new slot (#442, regression from 2.6)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes

#### Descripton

...

Ok round 2 sorry. Witholding a README update until arrows are added to all the game option screens which will come in separate PRs. This also includes some option_passport rework. As we discussed, I wanted to get some input on the changes so far.