### PR TITLE
option_graphics: offset title bar to match other menus

### DIFF
--- a/src/game/option_graphics.c
+++ b/src/game/option_graphics.c
@@ -87,7 +87,7 @@ static void Option_GraphicsInitText()
 {
     char buf[OPTION_LENGTH];
 
-    m_Text[TEXT_TITLE_BORDER] = Text_Create(0, TOP_Y, " ");
+    m_Text[TEXT_TITLE_BORDER] = Text_Create(0, TOP_Y - 2, " ");
     Text_CentreH(m_Text[TEXT_TITLE_BORDER], 1);
     Text_CentreV(m_Text[TEXT_TITLE_BORDER], 1);
 
@@ -95,7 +95,7 @@ static void Option_GraphicsInitText()
         Text_Create(0, TOP_Y, g_GameFlow.strings[GS_DETAIL_SELECT_DETAIL]);
     Text_CentreH(m_Text[TEXT_TITLE], 1);
     Text_CentreV(m_Text[TEXT_TITLE], 1);
-    Text_AddBackground(m_Text[TEXT_TITLE], ROW_WIDTH, 0, 0, 0);
+    Text_AddBackground(m_Text[TEXT_TITLE], ROW_WIDTH - 4, 0, 0, 0);
     Text_AddOutline(m_Text[TEXT_TITLE], 1);
 
     if (g_OptionSelected < TEXT_OPTION_MIN) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes

#### Descripton
Offset title bar to match other menus.
...


Pic:
![20220310_141118_Title](https://user-images.githubusercontent.com/81546780/157737916-053f6899-8144-408d-ae11-060dc1e1ed72.jpg)

