### PR TITLE
option_sound: fix rapid sound effect if input held down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - added music during the credits (#356)
 - added unobtainable pickups and kills stats support in the gameflow (#470)
 - fixed exploded mutant pods sometimes appearing unhatched on reload (#423)
+- fixed sound effects playing rapidly in sound menu if input held down (#467)
 
 ## [2.6.4](https://github.com/rr-/Tomb1Main/compare/2.6.3...2.6.4) - 2022-02-20
 - fixed crash when loading a legacy save and saving on a new slot (#442, regression from 2.6)

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Not all options are turned on by default. Refer to `Tomb1Main.json5` for details
 - fixed gun pickups disappearing in rare circumstances on save load (#406)
 - fixed broken dart ricochet effect
 - fixed exploded mutant pods sometimes appearing unhatched on reload
+- fixed sound effects playing rapidly in sound menu if input held down
 
 ## Showcase
 

--- a/src/game/option_sound.c
+++ b/src/game/option_sound.c
@@ -98,6 +98,8 @@ void Option_Sound(INVENTORY_ITEM *inv_item)
             g_Config.music_volume--;
             g_IDelay = true;
             g_IDCount = 10;
+            Music_SetVolume(g_Config.music_volume);
+            Sound_Effect(SFX_MENU_PASSPORT, NULL, SPM_ALWAYS);
             sprintf(buf, "| %2d", g_Config.music_volume);
             Text_ChangeText(m_Text[TEXT_MUSIC_VOLUME], buf);
             Settings_Write();
@@ -105,14 +107,11 @@ void Option_Sound(INVENTORY_ITEM *inv_item)
             g_Config.music_volume++;
             g_IDelay = true;
             g_IDCount = 10;
+            Music_SetVolume(g_Config.music_volume);
+            Sound_Effect(SFX_MENU_PASSPORT, NULL, SPM_ALWAYS);
             sprintf(buf, "| %2d", g_Config.music_volume);
             Text_ChangeText(m_Text[TEXT_MUSIC_VOLUME], buf);
             Settings_Write();
-        }
-
-        if (g_Input.left || g_Input.right) {
-            Music_SetVolume(g_Config.music_volume);
-            Sound_Effect(SFX_MENU_PASSPORT, NULL, SPM_ALWAYS);
         }
 
         if (g_Config.music_volume == MIN_VOLUME) {
@@ -131,6 +130,8 @@ void Option_Sound(INVENTORY_ITEM *inv_item)
             g_Config.sound_volume--;
             g_IDelay = true;
             g_IDCount = 10;
+            Sound_SetMasterVolume(g_Config.sound_volume);
+            Sound_Effect(SFX_MENU_PASSPORT, NULL, SPM_ALWAYS);
             sprintf(buf, "} %2d", g_Config.sound_volume);
             Text_ChangeText(m_Text[TEXT_SOUND_VOLUME], buf);
             Settings_Write();
@@ -138,14 +139,11 @@ void Option_Sound(INVENTORY_ITEM *inv_item)
             g_Config.sound_volume++;
             g_IDelay = true;
             g_IDCount = 10;
+            Sound_SetMasterVolume(g_Config.sound_volume);
+            Sound_Effect(SFX_MENU_PASSPORT, NULL, SPM_ALWAYS);
             sprintf(buf, "} %2d", g_Config.sound_volume);
             Text_ChangeText(m_Text[TEXT_SOUND_VOLUME], buf);
             Settings_Write();
-        }
-
-        if (g_Input.left || g_Input.right) {
-            Sound_SetMasterVolume(g_Config.sound_volume);
-            Sound_Effect(SFX_MENU_PASSPORT, NULL, SPM_ALWAYS);
         }
 
         if (g_Config.sound_volume == MIN_VOLUME) {


### PR DESCRIPTION
Resolves #467.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes

#### Descripton
Fixed sound effects playing rapidly in sound menu if input held down.
...
