### PR TITLE
wip: add fade effects to images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added contextual arrows to graphics option navigation (#462)
 - added a final statistics screen (#385)
 - added music during the credits (#356)
+- added fade effects to displayed images (#476)
 - added unobtainable pickups and kills stats support in the gameflow (#470)
 - fixed exploded mutant pods sometimes appearing unhatched on reload (#423)
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Not all options are turned on by default. Refer to `Tomb1Main.json5` for details
 - added contextual arrows to menu options
 - added a final statistics screen
 - added music during the credits
+- added fade effects to displayed images
 - added unobtainable pickups and kills stats support in the gameflow
 - changed internal game memory limit from 3.5 MB to 16 MB
 - changed moveable limit from 256 to 10240

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1161,13 +1161,24 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 
         case GFS_DISPLAY_PICTURE:
             if (level_type != GFL_SAVED) {
-                Output_FadeToTransparent(true);
+                Output_FadeToTransparent(true); // Fade in no black
                 GAMEFLOW_DISPLAY_PICTURE_DATA *data = seq->data;
                 Output_DisplayPicture(data->path);
                 Output_InitialisePolyList();
                 Output_CopyPictureToScreen();
                 Output_DumpScreen();
-                Shell_Wait(data->display_time);
+
+                Shell_Wait(data->display_time); // Show pic with no fade effect
+                Output_FadeToBlack(true); // Fade out to black
+
+                // fade out
+                while (Output_FadeIsAnimating()) {
+                    Output_InitialisePolyList();
+                    Output_CopyPictureToScreen();
+                    Output_DumpScreen();
+                }
+
+                Output_FadeReset(); // Reset fade
             }
             break;
 


### PR DESCRIPTION
#### Checklist

- [ ] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] I have added a changelog entry about what my pull request accomplishes

#### Description
Add fade effects to displayed images.
...

Currently a WIP. The images fade out but they do not fade in. There is also a flicker issue. Lastly, this does not yet work on the stats screen yet since that is a separate gameflow case statement, and I wanted to solve the image only case first. The code also has some temporary comments to explain my thought process. Here's a video below:

https://streamable.com/2aynpu