### PR TITLE
stats: stop all music after final statistics are displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/2.7...master)
 - added the option to pause sound in the inventory screen (#309)
+- fixed music rolling over to the main menu if main menu music disabled (#490)
 
 ## [2.7](https://github.com/rr-/Tomb1Main/compare/2.6.4...2.7) - 2022-03-16
 - added ability to automatically walk to pickups when nearby (#18)

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -523,4 +523,5 @@ void Stats_ShowTotal(const char *filename)
 
     Output_FadeReset();
     Text_RemoveAll();
+    Music_Stop();
 }


### PR DESCRIPTION
Resolves #490.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes

#### Description
Stop all music after final statistics are displayed.
...
