### PR TITLE
stats: stop all music after final statistics are displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/2.7...master)
 - added the option to pause sound in the inventory screen (#309)
 - fixed ghost margins during fade animation on HiDPI screens (#438)
+- fixed music rolling over to the main menu if main menu music disabled (#490)
 
 ## [2.7](https://github.com/rr-/Tomb1Main/compare/2.6.4...2.7) - 2022-03-16
 - added ability to automatically walk to pickups when nearby (#18)

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -6,6 +6,7 @@
 #include "game/gamebuf.h"
 #include "game/gameflow.h"
 #include "game/input.h"
+#include "game/music.h"
 #include "game/output.h"
 #include "game/savegame.h"
 #include "game/screen.h"
@@ -523,4 +524,5 @@ void Stats_ShowTotal(const char *filename)
 
     Output_FadeReset();
     Text_RemoveAll();
+    Music_Stop();
 }


### PR DESCRIPTION
Resolves #490.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes

#### Description
Fixed music rolling over to the main menu if main menu music is disabled.
...
