### PR TITLE
Refactor savegames to use start and current info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed music rolling over to the main menu if main menu music disabled (#490)
 - fixed Unfinished Business gameflow not using basic / detailed stats strings (#497, regression from 2.7)
 - fixed picking up multiple underwater pickups when walk_to_items is enabled (#500)
+- refactored save games to properly support start and current states
 
 ## [2.7](https://github.com/rr-/Tomb1Main/compare/2.6.4...2.7) - 2022-03-16
 - added ability to automatically walk to pickups when nearby (#18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - fixed music rolling over to the main menu if main menu music disabled (#490)
 - fixed Unfinished Business gameflow not using basic / detailed stats strings (#497, regression from 2.7)
 - fixed picking up multiple underwater pickups when walk_to_items is enabled (#500)
-- refactored save games to properly support start and current states
+- fixed incorrect Lara health when restarting a level
 
 ## [2.7](https://github.com/rr-/Tomb1Main/compare/2.6.4...2.7) - 2022-03-16
 - added ability to automatically walk to pickups when nearby (#18)

--- a/src/game/control.c
+++ b/src/game/control.c
@@ -305,7 +305,7 @@ int32_t ControlPhase(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
 
         CalculateCamera();
         Sound_UpdateEffects();
-        g_GameInfo.stats.timer++;
+        g_GameInfo.current[g_CurrentLevel].stats.timer++;
         Overlay_BarHealthTimerTick();
 
         m_FrameCount -= 0x10000;
@@ -727,10 +727,11 @@ void TestTriggers(int16_t *data, int32_t heavy)
             break;
 
         case TO_SECRET:
-            if ((g_GameInfo.stats.secret_flags & (1 << value))) {
+            if ((g_GameInfo.current[g_CurrentLevel].stats.secret_flags
+                 & (1 << value))) {
                 break;
             }
-            g_GameInfo.stats.secret_flags |= 1 << value;
+            g_GameInfo.current[g_CurrentLevel].stats.secret_flags |= 1 << value;
             Music_Play(13);
             break;
         }

--- a/src/game/demo.c
+++ b/src/game/demo.c
@@ -22,7 +22,7 @@ static uint32_t *m_DemoPtr = NULL;
 int32_t StartDemo(void)
 {
     TEXTSTRING *txt;
-    START_INFO start, *s;
+    RESUME_INFO start, *s;
 
     bool any_demos = false;
     for (int i = g_GameFlow.first_level_num; i < g_GameFlow.last_level_num;

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -24,7 +24,7 @@
 bool StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 {
     g_CurrentLevel = level_num;
-    g_GameInfo.level_type = level_type;
+    g_GameInfo.current_level_type = level_type;
     if (level_type == GFL_SAVED) {
         // reset start info to the defaults so that we do not do
         // GlobalItemReplace in the inventory initialization routines too early

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -23,8 +23,8 @@
 
 bool StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 {
-    LOG_DEBUG("level_type %d", level_type);
     g_CurrentLevel = level_num;
+    g_GameInfo.level_type = level_type;
     if (level_type == GFL_SAVED) {
         // reset start info to the defaults so that we do not do
         // GlobalItemReplace in the inventory initialization routines too early

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -53,12 +53,13 @@ bool StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 
 int32_t StopGame(void)
 {
-    Savegame_PersistGameToEndInfo(g_CurrentLevel);
+    Savegame_PersistGameToCurrentInfo(g_CurrentLevel);
 
     if (g_CurrentLevel == g_GameFlow.last_level_num) {
         g_GameInfo.bonus_flag = GBF_NGPLUS;
     } else {
-        Savegame_PersistGameToStartInfo(g_CurrentLevel + 1);
+        Savegame_CarryCurrentInfoToStartInfo(
+            g_CurrentLevel, g_CurrentLevel + 1);
         Savegame_ApplyLogicToStartInfo(g_CurrentLevel + 1);
     }
 
@@ -89,9 +90,12 @@ int32_t GameLoop(GAMEFLOW_LEVEL_TYPE level_type)
     InitialiseCamera();
 
     Stats_CalculateStats();
-    g_GameInfo.stats.max_pickup_count = Stats_GetPickups();
-    g_GameInfo.stats.max_kill_count = Stats_GetKillables();
-    g_GameInfo.stats.max_secret_count = Stats_GetSecrets();
+    g_GameInfo.current[g_CurrentLevel].stats.max_pickup_count =
+        Stats_GetPickups();
+    g_GameInfo.current[g_CurrentLevel].stats.max_kill_count =
+        Stats_GetKillables();
+    g_GameInfo.current[g_CurrentLevel].stats.max_secret_count =
+        Stats_GetSecrets();
 
     bool ask_for_save = g_GameFlow.enable_save_crystals
         && level_type == GFL_NORMAL

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -23,6 +23,7 @@
 
 bool StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 {
+    LOG_DEBUG("level_type %d", level_type);
     g_CurrentLevel = level_num;
     if (level_type == GFL_SAVED) {
         // reset start info to the defaults so that we do not do

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -604,8 +604,8 @@ static bool GameFlow_LoadScriptLevels(struct json_object_s *obj)
     int32_t level_count = jlvl_arr->length;
 
     g_GameFlow.levels = Memory_Alloc(sizeof(GAMEFLOW_LEVEL) * level_count);
-    g_GameInfo.start = Memory_Alloc(sizeof(START_INFO) * level_count);
-    g_GameInfo.end = Memory_Alloc(sizeof(END_INFO) * level_count);
+    g_GameInfo.start = Memory_Alloc(sizeof(RESUME_INFO) * level_count);
+    g_GameInfo.current = Memory_Alloc(sizeof(RESUME_INFO) * level_count);
 
     struct json_array_element_s *jlvl_elem = jlvl_arr->start;
     int level_num = 0;
@@ -889,7 +889,7 @@ void GameFlow_Shutdown(void)
     Memory_FreePointer(&g_GameFlow.savegame_fmt_legacy);
     Memory_FreePointer(&g_GameFlow.savegame_fmt_bson);
     Memory_FreePointer(&g_GameInfo.start);
-    Memory_FreePointer(&g_GameInfo.end);
+    Memory_FreePointer(&g_GameInfo.current);
 
     for (int i = 0; i < GS_NUMBER_OF; i++) {
         Memory_FreePointer(&g_GameFlow.strings[i]);

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1075,8 +1075,6 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 
     GAMEFLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
     GAMEFLOW_OPTION ret = GF_EXIT_TO_TITLE;
-    g_GameInfo.level_type = level_type;
-    LOG_DEBUG("g_GameInfo.level_type %d", g_GameInfo.level_type);
     while (seq->type != GFS_END) {
         LOG_INFO("seq %d %d", seq->type, seq->data);
 

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1075,6 +1075,8 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 
     GAMEFLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
     GAMEFLOW_OPTION ret = GF_EXIT_TO_TITLE;
+    g_GameInfo.level_type = level_type;
+    LOG_DEBUG("g_GameInfo.level_type %d", g_GameInfo.level_type);
     while (seq->type != GFS_END) {
         LOG_INFO("seq %d %d", seq->type, seq->data);
 

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -711,7 +711,7 @@ int32_t Display_Inventory(int inv_mode)
                 return GF_START_SAVED_GAME | g_InvExtraData[1];
             } else if (g_InvExtraData[0] == 1) {
                 // page 2: restart level
-                return GF_START_GAME | g_CurrentLevel;
+                return GF_RESTART_GAME | g_CurrentLevel;
             } else {
                 // page 3: exit game
                 return GF_EXIT_TO_TITLE;

--- a/src/game/inventry.c
+++ b/src/game/inventry.c
@@ -274,7 +274,7 @@ int32_t Display_Inventory(int inv_mode)
         g_Camera.number_frames = m_InvNFrames;
 
         if (g_Config.enable_timer_in_inventory) {
-            g_GameInfo.stats.timer += m_InvNFrames / 2;
+            g_GameInfo.current[g_CurrentLevel].stats.timer += m_InvNFrames / 2;
         }
 
         if (ring.rotating) {
@@ -699,7 +699,7 @@ int32_t Display_Inventory(int inv_mode)
                     g_GameInfo.bonus_flag = GBF_JAPANESE | GBF_NGPLUS;
                     break;
                 }
-                Savegame_InitStartEndInfo();
+                Savegame_InitStartCurrentInfo();
                 return GF_START_GAME | g_GameFlow.first_level_num;
             } else {
                 // page 3: exit game
@@ -737,7 +737,7 @@ int32_t Display_Inventory(int inv_mode)
                         g_GameInfo.bonus_flag = GBF_JAPANESE | GBF_NGPLUS;
                         break;
                     }
-                    Savegame_InitStartEndInfo();
+                    Savegame_InitStartCurrentInfo();
                     return GF_START_GAME | g_GameFlow.first_level_num;
                 } else {
                     Savegame_Save(g_InvExtraData[1], &g_GameInfo);

--- a/src/game/lara.h
+++ b/src/game/lara.h
@@ -14,7 +14,7 @@ void AnimateLaraUntil(ITEM_INFO *lara_item, int32_t goal);
 void UseItem(int16_t object_num);
 void ControlLaraExtra(int16_t item_num);
 void InitialiseLaraLoad(int16_t item_num);
-void InitialiseLara(void);
+void InitialiseLara(int32_t level_num);
 void InitialiseLaraInventory(int32_t level_num);
 void LaraInitialiseMeshes(int32_t level_num);
 

--- a/src/game/larafire.c
+++ b/src/game/larafire.c
@@ -600,7 +600,7 @@ int32_t FireWeapon(
 void HitTarget(ITEM_INFO *item, GAME_VECTOR *hitpos, int32_t damage)
 {
     if (item->hit_points > 0 && item->hit_points <= damage) {
-        g_GameInfo.stats.kill_count++;
+        g_GameInfo.current[g_CurrentLevel].stats.kill_count++;
     }
     item->hit_points -= damage;
     item->hit_status = 1;

--- a/src/game/laramisc.c
+++ b/src/game/laramisc.c
@@ -29,7 +29,6 @@ static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num);
 
 static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num)
 {
-    LOG_DEBUG("level_type %d", g_GameInfo.level_type);
     if (g_GameInfo.level_type == GFL_SAVED) {
         return &g_GameInfo.current[level_num];
     }
@@ -520,7 +519,6 @@ void InitialiseLaraInventory(int32_t level_num)
     Inv_RemoveAllItems();
 
     RESUME_INFO *resume = Lara_GetResumeInfo(level_num);
-    LOG_DEBUG("level_num %d", level_num);
 
     g_Lara.pistols.ammo = 1000;
     if (resume->flags.got_pistols) {

--- a/src/game/laramisc.c
+++ b/src/game/laramisc.c
@@ -520,6 +520,7 @@ void InitialiseLaraInventory(int32_t level_num)
     Inv_RemoveAllItems();
 
     RESUME_INFO *resume = Lara_GetResumeInfo(level_num);
+    LOG_DEBUG("level_num %d", level_num);
 
     g_Lara.pistols.ammo = 1000;
     if (resume->flags.got_pistols) {

--- a/src/game/laramisc.c
+++ b/src/game/laramisc.c
@@ -30,8 +30,10 @@ static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num);
 static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num)
 {
     if (g_GameInfo.level_type == GFL_SAVED) {
+        // Use current info for saved games.
         return &g_GameInfo.current[level_num];
     }
+    // Use start info for restart / level select.
     return &g_GameInfo.start[level_num];
 }
 

--- a/src/game/laramisc.c
+++ b/src/game/laramisc.c
@@ -25,15 +25,16 @@
 
 #define MOVE_TIMEOUT 90
 
-// static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num);
+static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num);
 
-// static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num)
-// {
-//     if (g_GameInfo.level_type == GFL_SAVED) {
-//         return &g_GameInfo.current[level_num];
-//     }
-//     return &g_GameInfo.start[level_num];
-// }
+static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num)
+{
+    LOG_DEBUG("level_type %d", g_GameInfo.level_type);
+    if (g_GameInfo.level_type == GFL_SAVED) {
+        return &g_GameInfo.current[level_num];
+    }
+    return &g_GameInfo.start[level_num];
+}
 
 void LaraControl(int16_t item_num)
 {
@@ -459,13 +460,13 @@ void InitialiseLaraLoad(int16_t item_num)
     }
 }
 
-void InitialiseLara(void)
+void InitialiseLara(int32_t level_num)
 {
-    RESUME_INFO *start = &g_GameInfo.start[g_CurrentLevel];
+    RESUME_INFO *resume = Lara_GetResumeInfo(level_num);
 
     g_LaraItem->collidable = 0;
     g_LaraItem->data = &g_Lara;
-    g_LaraItem->hit_points = start->lara_hitpoints;
+    g_LaraItem->hit_points = resume->lara_hitpoints;
 
     g_Lara.air = LARA_AIR;
     g_Lara.torso_y_rot = 0;
@@ -518,64 +519,64 @@ void InitialiseLaraInventory(int32_t level_num)
 {
     Inv_RemoveAllItems();
 
-    RESUME_INFO *start = &g_GameInfo.start[level_num];
+    RESUME_INFO *resume = Lara_GetResumeInfo(level_num);
 
     g_Lara.pistols.ammo = 1000;
-    if (start->flags.got_pistols) {
+    if (resume->flags.got_pistols) {
         Inv_AddItem(O_GUN_ITEM);
     }
 
-    if (start->flags.got_magnums) {
+    if (resume->flags.got_magnums) {
         Inv_AddItem(O_MAGNUM_ITEM);
-        g_Lara.magnums.ammo = start->magnum_ammo;
+        g_Lara.magnums.ammo = resume->magnum_ammo;
         GlobalItemReplace(O_MAGNUM_ITEM, O_MAG_AMMO_ITEM);
     } else {
-        int32_t ammo = start->magnum_ammo / MAGNUM_AMMO_QTY;
+        int32_t ammo = resume->magnum_ammo / MAGNUM_AMMO_QTY;
         for (int i = 0; i < ammo; i++) {
             Inv_AddItem(O_MAG_AMMO_ITEM);
         }
         g_Lara.magnums.ammo = 0;
     }
 
-    if (start->flags.got_uzis) {
+    if (resume->flags.got_uzis) {
         Inv_AddItem(O_UZI_ITEM);
-        g_Lara.uzis.ammo = start->uzi_ammo;
+        g_Lara.uzis.ammo = resume->uzi_ammo;
         GlobalItemReplace(O_UZI_ITEM, O_UZI_AMMO_ITEM);
     } else {
-        int32_t ammo = start->uzi_ammo / UZI_AMMO_QTY;
+        int32_t ammo = resume->uzi_ammo / UZI_AMMO_QTY;
         for (int i = 0; i < ammo; i++) {
             Inv_AddItem(O_UZI_AMMO_ITEM);
         }
         g_Lara.uzis.ammo = 0;
     }
 
-    if (start->flags.got_shotgun) {
+    if (resume->flags.got_shotgun) {
         Inv_AddItem(O_SHOTGUN_ITEM);
-        g_Lara.shotgun.ammo = start->shotgun_ammo;
+        g_Lara.shotgun.ammo = resume->shotgun_ammo;
         GlobalItemReplace(O_SHOTGUN_ITEM, O_SG_AMMO_ITEM);
     } else {
-        int32_t ammo = start->shotgun_ammo / SHOTGUN_AMMO_QTY;
+        int32_t ammo = resume->shotgun_ammo / SHOTGUN_AMMO_QTY;
         for (int i = 0; i < ammo; i++) {
             Inv_AddItem(O_SG_AMMO_ITEM);
         }
         g_Lara.shotgun.ammo = 0;
     }
 
-    for (int i = 0; i < start->num_scions; i++) {
+    for (int i = 0; i < resume->num_scions; i++) {
         Inv_AddItem(O_SCION_ITEM);
     }
 
-    for (int i = 0; i < start->num_medis; i++) {
+    for (int i = 0; i < resume->num_medis; i++) {
         Inv_AddItem(O_MEDI_ITEM);
     }
 
-    for (int i = 0; i < start->num_big_medis; i++) {
+    for (int i = 0; i < resume->num_big_medis; i++) {
         Inv_AddItem(O_BIGMEDI_ITEM);
     }
 
-    g_Lara.gun_status = start->gun_status;
-    g_Lara.gun_type = start->gun_type;
-    g_Lara.request_gun_type = start->gun_type;
+    g_Lara.gun_status = resume->gun_status;
+    g_Lara.gun_type = resume->gun_type;
+    g_Lara.request_gun_type = resume->gun_type;
 
     LaraInitialiseMeshes(level_num);
     InitialiseNewWeapon();
@@ -583,9 +584,9 @@ void InitialiseLaraInventory(int32_t level_num)
 
 void LaraInitialiseMeshes(int32_t level_num)
 {
-    RESUME_INFO *start = &g_GameInfo.start[level_num];
+    RESUME_INFO *resume = Lara_GetResumeInfo(level_num);
 
-    if (start->flags.costume) {
+    if (resume->flags.costume) {
         for (int i = 0; i < LM_NUMBER_OF; i++) {
             int32_t use_orig_mesh = i == LM_HEAD;
             g_Lara.mesh_ptrs[i] = g_Meshes
@@ -602,7 +603,7 @@ void LaraInitialiseMeshes(int32_t level_num)
     GAME_OBJECT_ID back_object_num = O_INVALID;
     GAME_OBJECT_ID hands_object_num = O_INVALID;
     GAME_OBJECT_ID holster_object_num = O_INVALID;
-    switch (start->gun_type) {
+    switch (resume->gun_type) {
     case LGT_SHOTGUN:
         hands_object_num = O_SHOTGUN;
         break;
@@ -617,7 +618,7 @@ void LaraInitialiseMeshes(int32_t level_num)
         break;
     }
 
-    if (start->flags.got_shotgun) {
+    if (resume->flags.got_shotgun) {
         back_object_num = O_SHOTGUN;
     }
 

--- a/src/game/laramisc.c
+++ b/src/game/laramisc.c
@@ -25,6 +25,16 @@
 
 #define MOVE_TIMEOUT 90
 
+// static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num);
+
+// static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num)
+// {
+//     if (g_GameInfo.level_type == GFL_SAVED) {
+//         return &g_GameInfo.current[level_num];
+//     }
+//     return &g_GameInfo.start[level_num];
+// }
+
 void LaraControl(int16_t item_num)
 {
     COLL_INFO coll = { 0 };
@@ -168,7 +178,7 @@ void LaraControl(int16_t item_num)
         item->hit_points = -1;
         if (!g_Lara.death_timer) {
             Music_Stop();
-            g_GameInfo.end[g_CurrentLevel].stats.death_count++;
+            g_GameInfo.current[g_CurrentLevel].stats.death_count++;
             if (g_GameInfo.current_save_slot != -1) {
                 Savegame_UpdateDeathCounters(
                     g_GameInfo.current_save_slot, &g_GameInfo);
@@ -451,7 +461,7 @@ void InitialiseLaraLoad(int16_t item_num)
 
 void InitialiseLara(void)
 {
-    START_INFO *start = &g_GameInfo.start[g_CurrentLevel];
+    RESUME_INFO *start = &g_GameInfo.start[g_CurrentLevel];
 
     g_LaraItem->collidable = 0;
     g_LaraItem->data = &g_Lara;
@@ -508,7 +518,7 @@ void InitialiseLaraInventory(int32_t level_num)
 {
     Inv_RemoveAllItems();
 
-    START_INFO *start = &g_GameInfo.start[level_num];
+    RESUME_INFO *start = &g_GameInfo.start[level_num];
 
     g_Lara.pistols.ammo = 1000;
     if (start->flags.got_pistols) {
@@ -573,7 +583,7 @@ void InitialiseLaraInventory(int32_t level_num)
 
 void LaraInitialiseMeshes(int32_t level_num)
 {
-    START_INFO *start = &g_GameInfo.start[level_num];
+    RESUME_INFO *start = &g_GameInfo.start[level_num];
 
     if (start->flags.costume) {
         for (int i = 0; i < LM_NUMBER_OF; i++) {

--- a/src/game/laramisc.c
+++ b/src/game/laramisc.c
@@ -29,7 +29,7 @@ static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num);
 
 static RESUME_INFO *Lara_GetResumeInfo(int32_t level_num)
 {
-    if (g_GameInfo.level_type == GFL_SAVED) {
+    if (g_GameInfo.current_level_type == GFL_SAVED) {
         // Use current info for saved games.
         return &g_GameInfo.current[level_num];
     }

--- a/src/game/objects/pickup.c
+++ b/src/game/objects/pickup.c
@@ -53,7 +53,7 @@ static void PickUp_GetItem(
     Inv_AddItem(item->object_number);
     item->status = IS_INVISIBLE;
     RemoveDrawnItem(item_num);
-    g_GameInfo.stats.pickup_count++;
+    g_GameInfo.current[g_CurrentLevel].stats.pickup_count++;
     g_Lara.interact_target.is_moving = false;
 }
 

--- a/src/game/objects/scion.c
+++ b/src/game/objects/scion.c
@@ -148,7 +148,7 @@ void Scion_Collision(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
             Inv_AddItem(item->object_number);
             item->status = IS_INVISIBLE;
             RemoveDrawnItem(item_num);
-            g_GameInfo.stats.pickup_count++;
+            g_GameInfo.current[g_CurrentLevel].stats.pickup_count++;
         }
     } else if (
         g_Input.action && g_Lara.gun_status == LGS_ARMLESS

--- a/src/game/option_compass.c
+++ b/src/game/option_compass.c
@@ -29,7 +29,7 @@ static void Option_CompassInitText(void)
     const int top_y = -100;
     const int row_height = 25;
     const int row_width = 225;
-    const GAME_STATS *stats = &g_GameInfo.stats;
+    const GAME_STATS *stats = &g_GameInfo.current[g_CurrentLevel].stats;
 
     int y = top_y;
     m_Text[TEXT_TITLE_BORDER] = Text_Create(0, y - 2, " ");
@@ -69,7 +69,7 @@ static void Option_CompassInitText(void)
     }
     sprintf(
         buf, g_GameFlow.strings[GS_STATS_SECRETS_FMT], secret_count,
-        g_GameInfo.stats.max_secret_count);
+        g_GameInfo.current[g_CurrentLevel].stats.max_secret_count);
     m_Text[TEXT_SECRETS] = Text_Create(0, y, buf);
     y += row_height;
 
@@ -106,7 +106,7 @@ void Option_Compass(INVENTORY_ITEM *inv_item)
             Option_CompassInitText();
         }
 
-        int32_t seconds = g_GameInfo.stats.timer / 30;
+        int32_t seconds = g_GameInfo.current[g_CurrentLevel].stats.timer / 30;
         int32_t hours = seconds / 3600;
         int32_t minutes = (seconds / 60) % 60;
         seconds %= 60;

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -441,8 +441,9 @@ void Overlay_DrawAmmoInfo(void)
 void Overlay_DrawPickups(void)
 {
     static int32_t old_game_timer = 0;
-    int16_t time = g_GameInfo.stats.timer - old_game_timer;
-    old_game_timer = g_GameInfo.stats.timer;
+    int16_t time =
+        g_GameInfo.current[g_CurrentLevel].stats.timer - old_game_timer;
+    old_game_timer = g_GameInfo.current[g_CurrentLevel].stats.timer;
 
     if (time > 0 && time < 60) {
         int32_t sprite_height =

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -21,6 +21,7 @@ static TEXTSTRING *m_AmmoText = NULL;
 static TEXTSTRING *m_FPSText = NULL;
 static int16_t m_BarOffsetY[6] = { 0 };
 static DISPLAYPU m_Pickups[MAX_PICKUPS] = { 0 };
+static int32_t m_OldGameTimer = 0;
 
 static RGBA8888 m_ColorBarMap[][COLOR_STEPS] = {
     // gold
@@ -440,10 +441,9 @@ void Overlay_DrawAmmoInfo(void)
 
 void Overlay_DrawPickups(void)
 {
-    static int32_t old_game_timer = 0;
     int16_t time =
-        g_GameInfo.current[g_CurrentLevel].stats.timer - old_game_timer;
-    old_game_timer = g_GameInfo.current[g_CurrentLevel].stats.timer;
+        g_GameInfo.current[g_CurrentLevel].stats.timer - m_OldGameTimer;
+    m_OldGameTimer = g_GameInfo.current[g_CurrentLevel].stats.timer;
 
     if (time > 0 && time < 60) {
         int32_t sprite_height =

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -168,7 +168,6 @@ void Savegame_SetCurrentPosition(int level_num)
 {
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         if (g_GameFlow.levels[i].level_type == GFL_CURRENT) {
-            LOG_DEBUG("g_CurrentLevel %d = %d i", g_CurrentLevel, i);
             g_GameInfo.current[g_CurrentLevel] = g_GameInfo.current[i];
         }
     }
@@ -176,7 +175,6 @@ void Savegame_SetCurrentPosition(int level_num)
 
 void Savegame_InitStartCurrentInfo(void)
 {
-    LOG_DEBUG("");
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         Savegame_ResetStartInfo(i);
         Savegame_ResetCurrentInfo(i);
@@ -189,7 +187,6 @@ void Savegame_InitStartCurrentInfo(void)
 
 void Savegame_ResetStartInfo(int level_num)
 {
-    LOG_DEBUG("");
     RESUME_INFO *start = &g_GameInfo.start[level_num];
     memset(start, 0, sizeof(RESUME_INFO));
     Savegame_ApplyLogicToStartInfo(level_num);
@@ -197,7 +194,6 @@ void Savegame_ResetStartInfo(int level_num)
 
 void Savegame_ApplyLogicToStartInfo(int level_num)
 {
-    LOG_DEBUG("");
     RESUME_INFO *start = &g_GameInfo.start[level_num];
 
     if (!g_Config.disable_healing_between_levels
@@ -257,14 +253,12 @@ void Savegame_ApplyLogicToStartInfo(int level_num)
 
 void Savegame_ResetCurrentInfo(int level_num)
 {
-    LOG_DEBUG("");
     RESUME_INFO *current = &g_GameInfo.current[level_num];
     memset(current, 0, sizeof(RESUME_INFO));
 }
 
 void Savegame_CarryCurrentInfoToStartInfo(int32_t src_level, int32_t dst_level)
 {
-    LOG_DEBUG("");
     memcpy(
         &g_GameInfo.start[dst_level], &g_GameInfo.current[src_level],
         sizeof(RESUME_INFO));
@@ -272,7 +266,6 @@ void Savegame_CarryCurrentInfoToStartInfo(int32_t src_level, int32_t dst_level)
 
 void Savegame_PersistGameToCurrentInfo(int level_num)
 {
-    LOG_DEBUG("");
     // Persist Lara's inventory to the current info.
     // Used to carry over Lara's inventory between levels.
 

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -168,6 +168,7 @@ void Savegame_SetCurrentPosition(int level_num)
 {
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         if (g_GameFlow.levels[i].level_type == GFL_CURRENT) {
+            LOG_DEBUG("g_CurrentLevel %d = %d i", g_CurrentLevel, i);
             g_GameInfo.current[g_CurrentLevel] = g_GameInfo.current[i];
         }
     }
@@ -175,6 +176,7 @@ void Savegame_SetCurrentPosition(int level_num)
 
 void Savegame_InitStartCurrentInfo(void)
 {
+    LOG_DEBUG("");
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         Savegame_ResetStartInfo(i);
         Savegame_ResetCurrentInfo(i);
@@ -187,6 +189,7 @@ void Savegame_InitStartCurrentInfo(void)
 
 void Savegame_ResetStartInfo(int level_num)
 {
+    LOG_DEBUG("");
     RESUME_INFO *start = &g_GameInfo.start[level_num];
     memset(start, 0, sizeof(RESUME_INFO));
     Savegame_ApplyLogicToStartInfo(level_num);
@@ -194,6 +197,7 @@ void Savegame_ResetStartInfo(int level_num)
 
 void Savegame_ApplyLogicToStartInfo(int level_num)
 {
+    LOG_DEBUG("");
     RESUME_INFO *start = &g_GameInfo.start[level_num];
 
     if (!g_Config.disable_healing_between_levels
@@ -253,12 +257,14 @@ void Savegame_ApplyLogicToStartInfo(int level_num)
 
 void Savegame_ResetCurrentInfo(int level_num)
 {
+    LOG_DEBUG("");
     RESUME_INFO *current = &g_GameInfo.current[level_num];
     memset(current, 0, sizeof(RESUME_INFO));
 }
 
 void Savegame_CarryCurrentInfoToStartInfo(int32_t src_level, int32_t dst_level)
 {
+    LOG_DEBUG("");
     memcpy(
         &g_GameInfo.start[dst_level], &g_GameInfo.current[src_level],
         sizeof(RESUME_INFO));
@@ -266,7 +272,8 @@ void Savegame_CarryCurrentInfoToStartInfo(int32_t src_level, int32_t dst_level)
 
 void Savegame_PersistGameToCurrentInfo(int level_num)
 {
-    // Persist Lara's inventory to the start info.
+    LOG_DEBUG("");
+    // Persist Lara's inventory to the current info.
     // Used to carry over Lara's inventory between levels.
 
     RESUME_INFO *current = &g_GameInfo.current[level_num];
@@ -382,7 +389,7 @@ bool Savegame_Save(int32_t slot_num, GAME_INFO *game_info)
 
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         if (g_GameFlow.levels[i].level_type == GFL_CURRENT) {
-            game_info->start[i] = game_info->start[g_CurrentLevel];
+            game_info->current[i] = game_info->current[g_CurrentLevel];
         }
     }
 

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -79,6 +79,8 @@ static void Savegame_LoadPreprocess(void)
             AlterFloorHeight(item, WALL_L * 2);
         }
     }
+
+    Savegame_InitStartCurrentInfo();
 }
 
 static void Savegame_LoadPostProcess(void)

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -173,11 +173,11 @@ void Savegame_SetCurrentPosition(int level_num)
     }
 }
 
-void Savegame_InitStartEndInfo(void)
+void Savegame_InitStartCurrentInfo(void)
 {
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         Savegame_ResetStartInfo(i);
-        Savegame_ResetEndInfo(i);
+        Savegame_ResetCurrentInfo(i);
         Savegame_ApplyLogicToStartInfo(i);
         g_GameInfo.start[i].flags.available = 0;
     }
@@ -187,14 +187,14 @@ void Savegame_InitStartEndInfo(void)
 
 void Savegame_ResetStartInfo(int level_num)
 {
-    START_INFO *start = &g_GameInfo.start[level_num];
-    memset(start, 0, sizeof(START_INFO));
+    RESUME_INFO *start = &g_GameInfo.start[level_num];
+    memset(start, 0, sizeof(RESUME_INFO));
     Savegame_ApplyLogicToStartInfo(level_num);
 }
 
 void Savegame_ApplyLogicToStartInfo(int level_num)
 {
-    START_INFO *start = &g_GameInfo.start[level_num];
+    RESUME_INFO *start = &g_GameInfo.start[level_num];
 
     if (!g_Config.disable_healing_between_levels
         || level_num == g_GameFlow.gym_level_num
@@ -251,84 +251,90 @@ void Savegame_ApplyLogicToStartInfo(int level_num)
     }
 }
 
-void Savegame_PersistGameToStartInfo(int level_num)
+void Savegame_ResetCurrentInfo(int level_num)
+{
+    RESUME_INFO *current = &g_GameInfo.current[level_num];
+    memset(current, 0, sizeof(RESUME_INFO));
+}
+
+void Savegame_CarryCurrentInfoToStartInfo(int32_t src_level, int32_t dst_level)
+{
+    memcpy(
+        &g_GameInfo.start[dst_level], &g_GameInfo.current[src_level],
+        sizeof(RESUME_INFO));
+}
+
+void Savegame_PersistGameToCurrentInfo(int level_num)
 {
     // Persist Lara's inventory to the start info.
     // Used to carry over Lara's inventory between levels.
 
-    START_INFO *start = &g_GameInfo.start[level_num];
+    RESUME_INFO *current = &g_GameInfo.current[level_num];
 
     if (g_LaraItem) {
-        start->lara_hitpoints = g_LaraItem->hit_points;
+        current->lara_hitpoints = g_LaraItem->hit_points;
     } else {
         // Carry over variables from previous levels if the current level
         // has no Lara object (such as the cutscene levels)
         for (int l = level_num - 1; l >= 0; l--) {
-            START_INFO *prev_start = &g_GameInfo.start[l];
+            RESUME_INFO *prev_current = &g_GameInfo.start[l];
             if (g_GameFlow.levels[l].level_type == GFL_NORMAL) {
-                start->lara_hitpoints = prev_start->lara_hitpoints;
+                current->lara_hitpoints = prev_current->lara_hitpoints;
                 break;
             }
         }
     }
 
-    start->flags.available = 1;
-    start->flags.costume = 0;
+    current->flags.available = 1;
+    current->flags.costume = 0;
 
-    start->pistol_ammo = 1000;
+    current->pistol_ammo = 1000;
     if (Inv_RequestItem(O_GUN_ITEM)) {
-        start->flags.got_pistols = 1;
+        current->flags.got_pistols = 1;
     } else {
-        start->flags.got_pistols = 0;
+        current->flags.got_pistols = 0;
     }
 
     if (Inv_RequestItem(O_MAGNUM_ITEM)) {
-        start->magnum_ammo = g_Lara.magnums.ammo;
-        start->flags.got_magnums = 1;
+        current->magnum_ammo = g_Lara.magnums.ammo;
+        current->flags.got_magnums = 1;
     } else {
-        start->magnum_ammo = Inv_RequestItem(O_MAG_AMMO_ITEM) * MAGNUM_AMMO_QTY;
-        start->flags.got_magnums = 0;
+        current->magnum_ammo =
+            Inv_RequestItem(O_MAG_AMMO_ITEM) * MAGNUM_AMMO_QTY;
+        current->flags.got_magnums = 0;
     }
 
     if (Inv_RequestItem(O_UZI_ITEM)) {
-        start->uzi_ammo = g_Lara.uzis.ammo;
-        start->flags.got_uzis = 1;
+        current->uzi_ammo = g_Lara.uzis.ammo;
+        current->flags.got_uzis = 1;
     } else {
-        start->uzi_ammo = Inv_RequestItem(O_UZI_AMMO_ITEM) * UZI_AMMO_QTY;
-        start->flags.got_uzis = 0;
+        current->uzi_ammo = Inv_RequestItem(O_UZI_AMMO_ITEM) * UZI_AMMO_QTY;
+        current->flags.got_uzis = 0;
     }
 
     if (Inv_RequestItem(O_SHOTGUN_ITEM)) {
-        start->shotgun_ammo = g_Lara.shotgun.ammo;
-        start->flags.got_shotgun = 1;
+        current->shotgun_ammo = g_Lara.shotgun.ammo;
+        current->flags.got_shotgun = 1;
     } else {
-        start->shotgun_ammo =
+        current->shotgun_ammo =
             Inv_RequestItem(O_SG_AMMO_ITEM) * SHOTGUN_AMMO_QTY;
-        start->flags.got_shotgun = 0;
+        current->flags.got_shotgun = 0;
     }
 
-    start->num_medis = Inv_RequestItem(O_MEDI_ITEM);
-    start->num_big_medis = Inv_RequestItem(O_BIGMEDI_ITEM);
-    start->num_scions = Inv_RequestItem(O_SCION_ITEM);
+    current->num_medis = Inv_RequestItem(O_MEDI_ITEM);
+    current->num_big_medis = Inv_RequestItem(O_BIGMEDI_ITEM);
+    current->num_scions = Inv_RequestItem(O_SCION_ITEM);
 
-    start->gun_type = g_Lara.gun_type;
+    current->gun_type = g_Lara.gun_type;
     if (g_Lara.gun_status == LGS_READY) {
-        start->gun_status = LGS_READY;
+        current->gun_status = LGS_READY;
     } else {
-        start->gun_status = LGS_ARMLESS;
+        current->gun_status = LGS_ARMLESS;
     }
-}
 
-void Savegame_ResetEndInfo(int level_num)
-{
-    END_INFO *end = &g_GameInfo.end[level_num];
-    memset(end, 0, sizeof(END_INFO));
-}
-
-void Savegame_PersistGameToEndInfo(int level_num)
-{
-    END_INFO *end = &g_GameInfo.end[level_num];
-    end->stats = g_GameInfo.stats;
+    memcpy(
+        &current->stats, &g_GameInfo.current[g_CurrentLevel].stats,
+        sizeof(GAME_STATS));
 }
 
 int32_t Savegame_GetLevelNumber(int32_t slot_num)
@@ -372,8 +378,7 @@ bool Savegame_Save(int32_t slot_num, GAME_INFO *game_info)
 
     File_CreateDirectory(SAVES_DIR);
 
-    Savegame_PersistGameToStartInfo(g_CurrentLevel);
-    Savegame_PersistGameToEndInfo(g_CurrentLevel);
+    Savegame_PersistGameToCurrentInfo(g_CurrentLevel);
 
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         if (g_GameFlow.levels[i].level_type == GFL_CURRENT) {

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -331,10 +331,6 @@ void Savegame_PersistGameToCurrentInfo(int level_num)
     } else {
         current->gun_status = LGS_ARMLESS;
     }
-
-    memcpy(
-        &current->stats, &g_GameInfo.current[level_num].stats,
-        sizeof(GAME_STATS));
 }
 
 int32_t Savegame_GetLevelNumber(int32_t slot_num)

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -164,15 +164,6 @@ static void Savegame_LoadPostProcess(void)
     g_Lara.LOT.target_box = NO_BOX;
 }
 
-void Savegame_SetCurrentPosition(int level_num)
-{
-    for (int i = 0; i < g_GameFlow.level_count; i++) {
-        if (g_GameFlow.levels[i].level_type == GFL_CURRENT) {
-            g_GameInfo.current[g_CurrentLevel] = g_GameInfo.current[i];
-        }
-    }
-}
-
 void Savegame_InitStartCurrentInfo(void)
 {
     for (int i = 0; i < g_GameFlow.level_count; i++) {

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -168,7 +168,7 @@ void Savegame_SetCurrentPosition(int level_num)
 {
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         if (g_GameFlow.levels[i].level_type == GFL_CURRENT) {
-            g_GameInfo.start[g_CurrentLevel] = g_GameInfo.start[i];
+            g_GameInfo.current[g_CurrentLevel] = g_GameInfo.current[i];
         }
     }
 }
@@ -277,7 +277,7 @@ void Savegame_PersistGameToCurrentInfo(int level_num)
         // Carry over variables from previous levels if the current level
         // has no Lara object (such as the cutscene levels)
         for (int l = level_num - 1; l >= 0; l--) {
-            RESUME_INFO *prev_current = &g_GameInfo.start[l];
+            RESUME_INFO *prev_current = &g_GameInfo.current[l];
             if (g_GameFlow.levels[l].level_type == GFL_NORMAL) {
                 current->lara_hitpoints = prev_current->lara_hitpoints;
                 break;
@@ -333,7 +333,7 @@ void Savegame_PersistGameToCurrentInfo(int level_num)
     }
 
     memcpy(
-        &current->stats, &g_GameInfo.current[g_CurrentLevel].stats,
+        &current->stats, &g_GameInfo.current[level_num].stats,
         sizeof(GAME_STATS));
 }
 

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -262,20 +262,7 @@ void Savegame_PersistGameToCurrentInfo(int level_num)
 
     RESUME_INFO *current = &g_GameInfo.current[level_num];
 
-    if (g_LaraItem) {
-        current->lara_hitpoints = g_LaraItem->hit_points;
-    } else {
-        // Carry over variables from previous levels if the current level
-        // has no Lara object (such as the cutscene levels)
-        for (int l = level_num - 1; l >= 0; l--) {
-            RESUME_INFO *prev_current = &g_GameInfo.current[l];
-            if (g_GameFlow.levels[l].level_type == GFL_NORMAL) {
-                current->lara_hitpoints = prev_current->lara_hitpoints;
-                break;
-            }
-        }
-    }
-
+    current->lara_hitpoints = g_LaraItem->hit_points;
     current->flags.available = 1;
     current->flags.costume = 0;
 

--- a/src/game/savegame.h
+++ b/src/game/savegame.h
@@ -14,7 +14,7 @@
 
 #include "game/savegame_common.h"
 
-void Savegame_InitStartEndInfo(void);
+void Savegame_InitStartCurrentInfo(void);
 
 int32_t Savegame_GetLevelNumber(int32_t slot_num);
 

--- a/src/game/savegame_bson.c
+++ b/src/game/savegame_bson.c
@@ -280,6 +280,8 @@ static bool Savegame_BSON_LoadDiscontinuedStartInfo(
         start->flags.costume = json_object_get_bool(start_obj, "costume", 0);
         // Start and current are the same for legacy saves.
         memcpy(&game_info->current[i], start, sizeof(RESUME_INFO));
+        // Max Lara's starting HP for legacy saves instead of using current HP.
+        start->lara_hitpoints = LARA_HITPOINTS;
     }
     return true;
 }

--- a/src/game/savegame_bson.c
+++ b/src/game/savegame_bson.c
@@ -1048,6 +1048,7 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     if (!Savegame_BSON_LoadResumeInfo(
             json_object_get_array(root_obj, "current_info"),
             game_info->current)) {
+        LOG_DEBUG("CHECKING LEGACY SAVES...");
         // Check for 2.6 and 2.7 legacy start and end info.
         if (!Savegame_BSON_LoadDiscontinuedStartInfo(
                 json_object_get_array(root_obj, "start_info"), game_info)) {

--- a/src/game/savegame_bson.c
+++ b/src/game/savegame_bson.c
@@ -36,10 +36,12 @@ static void SaveGame_BSON_SaveRaw(MYFILE *fp, struct json_value_s *root);
 static bool Savegame_BSON_IsValidItemObject(
     int16_t saved_obj_num, int16_t current_obj_num);
 static struct json_value_s *Savegame_BSON_ParseFromFile(MYFILE *fp);
-static bool Savegame_BSON_LoadStartInfo(
-    struct json_array_s *levels_arr, GAME_INFO *game_info);
-static bool Savegame_BSON_LoadEndInfo(
-    struct json_array_s *levels_arr, GAME_INFO *game_info);
+static bool Savegame_BSON_LoadResumeInfo(
+    struct json_array_s *levels_arr, RESUME_INFO *resume_info);
+static bool Savegame_BSON_LoadDiscontinuedStartInfo(
+    struct json_array_s *start_arr, GAME_INFO *game_info);
+static bool Savegame_BSON_LoadDiscontinuedEndInfo(
+    struct json_array_s *end_arr, GAME_INFO *game_info);
 static bool Savegame_BSON_LoadMisc(
     struct json_object_s *misc_obj, GAME_INFO *game_info);
 static bool Savegame_BSON_LoadInventory(struct json_object_s *inv_obj);
@@ -52,8 +54,8 @@ static bool Savegame_BSON_LoadAmmo(
 static bool Savegame_BSON_LoadLOT(struct json_object_s *lot_obj, LOT_INFO *lot);
 static bool Savegame_BSON_LoadLara(
     struct json_object_s *lara_obj, LARA_INFO *lara);
-static struct json_array_s *Savegame_BSON_DumpStartInfo(GAME_INFO *game_info);
-static struct json_array_s *Savegame_BSON_DumpEndInfo(GAME_INFO *game_info);
+static struct json_array_s *Savegame_BSON_DumpResumeInfo(
+    RESUME_INFO *game_info);
 static struct json_object_s *Savegame_BSON_DumpMisc(GAME_INFO *game_info);
 static struct json_object_s *Savegame_BSON_DumpInventory(void);
 static struct json_object_s *Savegame_BSON_DumpFlipmaps(void);
@@ -163,13 +165,81 @@ static struct json_value_s *Savegame_BSON_ParseFromFile(MYFILE *fp)
     return ret;
 }
 
-static bool Savegame_BSON_LoadStartInfo(
+static bool Savegame_BSON_LoadResumeInfo(
+    struct json_array_s *resume_arr, RESUME_INFO *resume_info)
+{
+    assert(resume_info);
+    if (!resume_arr) {
+        LOG_ERROR("Malformed save: invalid or missing start resume array");
+        return false;
+    }
+    if ((signed)resume_arr->length != g_GameFlow.level_count) {
+        LOG_ERROR(
+            "Malformed save: expected %d resume info elements, got %d",
+            g_GameFlow.level_count, resume_arr->length);
+        return false;
+    }
+    for (int i = 0; i < (signed)resume_arr->length; i++) {
+        struct json_object_s *resume_obj = json_array_get_object(resume_arr, i);
+        if (!resume_obj) {
+            LOG_ERROR("Malformed save: invalid resume info");
+            return false;
+        }
+        RESUME_INFO *resume = &resume_info[i];
+        resume->lara_hitpoints = json_object_get_int(
+            resume_obj, "lara_hitpoints", g_Config.start_lara_hitpoints);
+        resume->pistol_ammo = json_object_get_int(resume_obj, "pistol_ammo", 0);
+        resume->magnum_ammo = json_object_get_int(resume_obj, "magnum_ammo", 0);
+        resume->uzi_ammo = json_object_get_int(resume_obj, "uzi_ammo", 0);
+        resume->shotgun_ammo =
+            json_object_get_int(resume_obj, "shotgun_ammo", 0);
+        resume->num_medis = json_object_get_int(resume_obj, "num_medis", 0);
+        resume->num_big_medis =
+            json_object_get_int(resume_obj, "num_big_medis", 0);
+        resume->num_scions = json_object_get_int(resume_obj, "num_scions", 0);
+        resume->gun_status = json_object_get_int(resume_obj, "gun_status", 0);
+        resume->gun_type = json_object_get_int(resume_obj, "gun_type", 0);
+        resume->flags.available =
+            json_object_get_bool(resume_obj, "available", 0);
+        resume->flags.got_pistols =
+            json_object_get_bool(resume_obj, "got_pistols", 0);
+        resume->flags.got_magnums =
+            json_object_get_bool(resume_obj, "got_magnums", 0);
+        resume->flags.got_uzis =
+            json_object_get_bool(resume_obj, "got_uzis", 0);
+        resume->flags.got_shotgun =
+            json_object_get_bool(resume_obj, "got_shotgun", 0);
+        resume->flags.costume = json_object_get_bool(resume_obj, "costume", 0);
+
+        resume->stats.timer =
+            json_object_get_int(resume_obj, "timer", resume->stats.timer);
+        resume->stats.secret_flags = json_object_get_int(
+            resume_obj, "secrets", resume->stats.secret_flags);
+        resume->stats.kill_count =
+            json_object_get_int(resume_obj, "kills", resume->stats.kill_count);
+        resume->stats.pickup_count = json_object_get_int(
+            resume_obj, "pickups", resume->stats.pickup_count);
+        resume->stats.death_count = json_object_get_int(
+            resume_obj, "deaths", resume->stats.death_count);
+        resume->stats.max_secret_count = json_object_get_int(
+            resume_obj, "max_secrets", resume->stats.max_secret_count);
+        resume->stats.max_kill_count = json_object_get_int(
+            resume_obj, "max_kills", resume->stats.max_kill_count);
+        resume->stats.max_pickup_count = json_object_get_int(
+            resume_obj, "max_pickups", resume->stats.max_pickup_count);
+    }
+    return true;
+}
+
+static bool Savegame_BSON_LoadDiscontinuedStartInfo(
     struct json_array_s *start_arr, GAME_INFO *game_info)
 {
+    // This function solely exists for backward compatibility with 2.6 and 2.7
+    // saves.
     assert(game_info);
     assert(game_info->start);
     if (!start_arr) {
-        LOG_ERROR("Malformed save: invalid or missing start info array");
+        LOG_ERROR("Malformed save: invalid or missing start resume array");
         return false;
     }
     if ((signed)start_arr->length != g_GameFlow.level_count) {
@@ -181,10 +251,11 @@ static bool Savegame_BSON_LoadStartInfo(
     for (int i = 0; i < (signed)start_arr->length; i++) {
         struct json_object_s *start_obj = json_array_get_object(start_arr, i);
         if (!start_obj) {
-            LOG_ERROR("Malformed save: invalid start info");
+            LOG_ERROR("Malformed save: invalid resume info");
             return false;
         }
-        START_INFO *start = &game_info->start[i];
+        RESUME_INFO *start = &game_info->start[i];
+        RESUME_INFO *current = &game_info->current[i];
         start->lara_hitpoints = json_object_get_int(
             start_obj, "lara_hitpoints", g_Config.start_lara_hitpoints);
         start->pistol_ammo = json_object_get_int(start_obj, "pistol_ammo", 0);
@@ -207,32 +278,37 @@ static bool Savegame_BSON_LoadStartInfo(
         start->flags.got_shotgun =
             json_object_get_bool(start_obj, "got_shotgun", 0);
         start->flags.costume = json_object_get_bool(start_obj, "costume", 0);
+        // Start and current are the same for legacy saves.
+        memcpy(&current, &start, sizeof(RESUME_INFO));
     }
     return true;
 }
 
-static bool Savegame_BSON_LoadEndInfo(
+static bool Savegame_BSON_LoadDiscontinuedEndInfo(
     struct json_array_s *end_arr, GAME_INFO *game_info)
 {
+    // This function solely exists for backward compatibility with 2.6 and 2.7
+    // saves.
     assert(game_info);
-    assert(game_info->end);
+    assert(game_info->current);
     if (!end_arr) {
-        LOG_ERROR("Malformed save: invalid or missing end info array");
+        LOG_ERROR("Malformed save: invalid or missing resume info array");
         return false;
     }
     if ((signed)end_arr->length != g_GameFlow.level_count) {
         LOG_ERROR(
-            "Malformed save: expected %d end info elements, got %d",
+            "Malformed save: expected %d resume info elements, got %d",
             g_GameFlow.level_count, end_arr->length);
         return false;
     }
     for (int i = 0; i < (signed)end_arr->length; i++) {
         struct json_object_s *end_obj = json_array_get_object(end_arr, i);
         if (!end_obj) {
-            LOG_ERROR("Malformed save: invalid end info");
+            LOG_ERROR("Malformed save: invalid resume info");
             return false;
         }
-        END_INFO *end = &game_info->end[i];
+        RESUME_INFO *start = &game_info->start[i];
+        RESUME_INFO *end = &game_info->current[i];
         end->stats.timer =
             json_object_get_int(end_obj, "timer", end->stats.timer);
         end->stats.secret_flags =
@@ -249,9 +325,10 @@ static bool Savegame_BSON_LoadEndInfo(
             end_obj, "max_kills", end->stats.max_kill_count);
         end->stats.max_pickup_count = json_object_get_int(
             end_obj, "max_pickups", end->stats.max_pickup_count);
+        // Start and current are the same for legacy saves.
+        memcpy(&start->stats, &end->stats, sizeof(GAME_STATS));
     }
     game_info->death_counter_supported = true;
-    game_info->stats = game_info->end[g_CurrentLevel].stats;
     return true;
 }
 
@@ -647,59 +724,53 @@ static bool Savegame_BSON_LoadLara(
     return true;
 }
 
-static struct json_array_s *Savegame_BSON_DumpStartInfo(GAME_INFO *game_info)
+static struct json_array_s *Savegame_BSON_DumpResumeInfo(
+    RESUME_INFO *resume_info)
 {
-    struct json_array_s *start_arr = json_array_new();
-    assert(game_info->start);
+    struct json_array_s *resume_arr = json_array_new();
+    assert(resume_info);
     for (int i = 0; i < g_GameFlow.level_count; i++) {
-        START_INFO *start = &game_info->start[i];
-        struct json_object_s *start_obj = json_object_new();
+        RESUME_INFO *resume = &resume_info[i];
+        struct json_object_s *resume_obj = json_object_new();
         json_object_append_int(
-            start_obj, "lara_hitpoints", start->lara_hitpoints);
-        json_object_append_int(start_obj, "pistol_ammo", start->pistol_ammo);
-        json_object_append_int(start_obj, "magnum_ammo", start->magnum_ammo);
-        json_object_append_int(start_obj, "uzi_ammo", start->uzi_ammo);
-        json_object_append_int(start_obj, "shotgun_ammo", start->shotgun_ammo);
-        json_object_append_int(start_obj, "num_medis", start->num_medis);
+            resume_obj, "lara_hitpoints", resume->lara_hitpoints);
+        json_object_append_int(resume_obj, "pistol_ammo", resume->pistol_ammo);
+        json_object_append_int(resume_obj, "magnum_ammo", resume->magnum_ammo);
+        json_object_append_int(resume_obj, "uzi_ammo", resume->uzi_ammo);
         json_object_append_int(
-            start_obj, "num_big_medis", start->num_big_medis);
-        json_object_append_int(start_obj, "num_scions", start->num_scions);
-        json_object_append_int(start_obj, "gun_status", start->gun_status);
-        json_object_append_int(start_obj, "gun_type", start->gun_type);
-        json_object_append_bool(start_obj, "available", start->flags.available);
+            resume_obj, "shotgun_ammo", resume->shotgun_ammo);
+        json_object_append_int(resume_obj, "num_medis", resume->num_medis);
+        json_object_append_int(
+            resume_obj, "num_big_medis", resume->num_big_medis);
+        json_object_append_int(resume_obj, "num_scions", resume->num_scions);
+        json_object_append_int(resume_obj, "gun_status", resume->gun_status);
+        json_object_append_int(resume_obj, "gun_type", resume->gun_type);
         json_object_append_bool(
-            start_obj, "got_pistols", start->flags.got_pistols);
+            resume_obj, "available", resume->flags.available);
         json_object_append_bool(
-            start_obj, "got_magnums", start->flags.got_magnums);
-        json_object_append_bool(start_obj, "got_uzis", start->flags.got_uzis);
+            resume_obj, "got_pistols", resume->flags.got_pistols);
         json_object_append_bool(
-            start_obj, "got_shotgun", start->flags.got_shotgun);
-        json_object_append_bool(start_obj, "costume", start->flags.costume);
-        json_array_append_object(start_arr, start_obj);
+            resume_obj, "got_magnums", resume->flags.got_magnums);
+        json_object_append_bool(resume_obj, "got_uzis", resume->flags.got_uzis);
+        json_object_append_bool(
+            resume_obj, "got_shotgun", resume->flags.got_shotgun);
+        json_object_append_bool(resume_obj, "costume", resume->flags.costume);
+        json_object_append_int(resume_obj, "timer", resume->stats.timer);
+        json_object_append_int(resume_obj, "kills", resume->stats.kill_count);
+        json_object_append_int(
+            resume_obj, "secrets", resume->stats.secret_flags);
+        json_object_append_int(
+            resume_obj, "pickups", resume->stats.pickup_count);
+        json_object_append_int(resume_obj, "deaths", resume->stats.death_count);
+        json_object_append_int(
+            resume_obj, "max_kills", resume->stats.max_kill_count);
+        json_object_append_int(
+            resume_obj, "max_secrets", resume->stats.max_secret_count);
+        json_object_append_int(
+            resume_obj, "max_pickups", resume->stats.max_pickup_count);
+        json_array_append_object(resume_arr, resume_obj);
     }
-    return start_arr;
-}
-
-static struct json_array_s *Savegame_BSON_DumpEndInfo(GAME_INFO *game_info)
-{
-    struct json_array_s *end_arr = json_array_new();
-    assert(game_info->end);
-    for (int i = 0; i < g_GameFlow.level_count; i++) {
-        END_INFO *end = &game_info->end[i];
-        struct json_object_s *end_obj = json_object_new();
-        json_object_append_int(end_obj, "timer", end->stats.timer);
-        json_object_append_int(end_obj, "kills", end->stats.kill_count);
-        json_object_append_int(end_obj, "secrets", end->stats.secret_flags);
-        json_object_append_int(end_obj, "pickups", end->stats.pickup_count);
-        json_object_append_int(end_obj, "deaths", end->stats.death_count);
-        json_object_append_int(end_obj, "max_kills", end->stats.max_kill_count);
-        json_object_append_int(
-            end_obj, "max_secrets", end->stats.max_secret_count);
-        json_object_append_int(
-            end_obj, "max_pickups", end->stats.max_pickup_count);
-        json_array_append_object(end_arr, end_obj);
-    }
-    return end_arr;
+    return resume_arr;
 }
 
 static struct json_object_s *Savegame_BSON_DumpMisc(GAME_INFO *game_info)
@@ -969,14 +1040,23 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         goto cleanup;
     }
 
-    if (!Savegame_BSON_LoadStartInfo(
-            json_object_get_array(root_obj, "start_info"), game_info)) {
+    if (!Savegame_BSON_LoadResumeInfo(
+            json_object_get_array(root_obj, "start_info"), game_info->start)) {
         goto cleanup;
     }
 
-    if (!Savegame_BSON_LoadEndInfo(
-            json_object_get_array(root_obj, "end_info"), game_info)) {
-        goto cleanup;
+    if (!Savegame_BSON_LoadResumeInfo(
+            json_object_get_array(root_obj, "current_info"),
+            game_info->current)) {
+        // Check for 2.6 and 2.7 legacy start and end info.
+        if (!Savegame_BSON_LoadDiscontinuedStartInfo(
+                json_object_get_array(root_obj, "start_info"), game_info)) {
+            goto cleanup;
+        }
+        if (!Savegame_BSON_LoadDiscontinuedEndInfo(
+                json_object_get_array(root_obj, "end_info"), game_info)) {
+            goto cleanup;
+        }
     }
 
     Savegame_SetCurrentPosition(g_CurrentLevel);
@@ -1026,9 +1106,10 @@ void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
     json_object_append_object(
         root_obj, "misc", Savegame_BSON_DumpMisc(game_info));
     json_object_append_array(
-        root_obj, "start_info", Savegame_BSON_DumpStartInfo(game_info));
+        root_obj, "start_info", Savegame_BSON_DumpResumeInfo(game_info->start));
     json_object_append_array(
-        root_obj, "end_info", Savegame_BSON_DumpEndInfo(game_info));
+        root_obj, "current_info",
+        Savegame_BSON_DumpResumeInfo(game_info->current));
     json_object_append_object(
         root_obj, "inventory", Savegame_BSON_DumpInventory());
     json_object_append_object(
@@ -1053,26 +1134,30 @@ bool Savegame_BSON_UpdateDeathCounters(MYFILE *fp, GAME_INFO *game_info)
         goto cleanup;
     }
 
-    struct json_array_s *end_arr = json_object_get_array(root_obj, "end_info");
-    if (!end_arr) {
-        LOG_ERROR("Malformed save: invalid or missing end info array");
-        goto cleanup;
-    }
-    if ((signed)end_arr->length != g_GameFlow.level_count) {
-        LOG_ERROR(
-            "Malformed save: expected %d end info elements, got %d",
-            g_GameFlow.level_count, end_arr->length);
-        goto cleanup;
-    }
-    for (int i = 0; i < (signed)end_arr->length; i++) {
-        struct json_object_s *end_obj = json_array_get_object(end_arr, i);
-        if (!end_obj) {
-            LOG_ERROR("Malformed save: invalid end info");
+    struct json_array_s *current_arr =
+        json_object_get_array(root_obj, "current_info");
+    if (!current_arr) {
+        current_arr = json_object_get_array(root_obj, "end_info");
+        if (!current_arr) {
+            LOG_ERROR("Malformed save: invalid or missing current info array");
             goto cleanup;
         }
-        END_INFO *end = &game_info->end[i];
-        json_object_evict_key(end_obj, "deaths");
-        json_object_append_int(end_obj, "deaths", end->stats.death_count);
+    }
+    if ((signed)current_arr->length != g_GameFlow.level_count) {
+        LOG_ERROR(
+            "Malformed save: expected %d current info elements, got %d",
+            g_GameFlow.level_count, current_arr->length);
+        goto cleanup;
+    }
+    for (int i = 0; i < (signed)current_arr->length; i++) {
+        struct json_object_s *cur_obj = json_array_get_object(current_arr, i);
+        if (!cur_obj) {
+            LOG_ERROR("Malformed save: invalid current info");
+            goto cleanup;
+        }
+        RESUME_INFO *current = &game_info->current[i];
+        json_object_evict_key(cur_obj, "deaths");
+        json_object_append_int(cur_obj, "deaths", current->stats.death_count);
     }
 
     File_Seek(fp, 0, FILE_SEEK_SET);

--- a/src/game/savegame_common.h
+++ b/src/game/savegame_common.h
@@ -20,7 +20,3 @@ void Savegame_ApplyLogicToStartInfo(int level_num);
 void Savegame_ResetCurrentInfo(int level_num);
 void Savegame_CarryCurrentInfoToStartInfo(int32_t src_level, int32_t dst_level);
 void Savegame_PersistGameToCurrentInfo(int level_num);
-
-#ifdef SAVEGAME_IMPL
-void Savegame_SetCurrentPosition(int level_num);
-#endif

--- a/src/game/savegame_common.h
+++ b/src/game/savegame_common.h
@@ -16,10 +16,10 @@ typedef struct SAVEGAME_INFO {
 } SAVEGAME_INFO;
 
 void Savegame_ResetStartInfo(int level_num);
-void Savegame_PersistGameToStartInfo(int level_num);
 void Savegame_ApplyLogicToStartInfo(int level_num);
-void Savegame_ResetEndInfo(int level_num);
-void Savegame_PersistGameToEndInfo(int level_num);
+void Savegame_ResetCurrentInfo(int level_num);
+void Savegame_CarryCurrentInfoToStartInfo(int32_t src_level, int32_t dst_level);
+void Savegame_PersistGameToCurrentInfo(int level_num);
 
 #ifdef SAVEGAME_IMPL
 void Savegame_SetCurrentPosition(int level_num);

--- a/src/game/savegame_legacy.c
+++ b/src/game/savegame_legacy.c
@@ -437,6 +437,10 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         current->flags.got_uzis = flags & 8 ? 1 : 0;
         current->flags.got_shotgun = flags & 16 ? 1 : 0;
         current->flags.costume = flags & 32 ? 1 : 0;
+        // Start and current are the same for legacy saves.
+        memcpy(&game_info->start[i], current, sizeof(RESUME_INFO));
+        // Max Lara's starting HP for legacy saves instead of using current HP.
+        game_info->start[i].lara_hitpoints = LARA_HITPOINTS;
     }
 
     Savegame_Legacy_Read(
@@ -450,9 +454,6 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     Savegame_Legacy_Read(
         &game_info->current[g_CurrentLevel].stats.pickup_count,
         sizeof(uint8_t));
-
-    // Legacy saves don't have start and current so use current for both
-    memcpy(game_info->start, game_info->current, sizeof(RESUME_INFO));
 
     Savegame_Legacy_Read(&game_info->bonus_flag, sizeof(uint8_t));
 
@@ -605,14 +606,17 @@ void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
         Savegame_Legacy_Write(&flags, sizeof(uint16_t));
     }
 
-    Savegame_Legacy_Write(&game_info->current->stats.timer, sizeof(uint32_t));
     Savegame_Legacy_Write(
-        &game_info->current->stats.kill_count, sizeof(uint32_t));
+        &game_info->current[g_CurrentLevel].stats.timer, sizeof(uint32_t));
     Savegame_Legacy_Write(
-        &game_info->current->stats.secret_flags, sizeof(uint16_t));
+        &game_info->current[g_CurrentLevel].stats.kill_count, sizeof(uint32_t));
+    Savegame_Legacy_Write(
+        &game_info->current[g_CurrentLevel].stats.secret_flags,
+        sizeof(uint16_t));
     Savegame_Legacy_Write(&g_CurrentLevel, sizeof(uint16_t));
     Savegame_Legacy_Write(
-        &game_info->current->stats.pickup_count, sizeof(uint8_t));
+        &game_info->current[g_CurrentLevel].stats.pickup_count,
+        sizeof(uint8_t));
     Savegame_Legacy_Write(&game_info->bonus_flag, sizeof(uint8_t));
 
     SAVEGAME_LEGACY_ITEM_STATS item_stats = {

--- a/src/game/savegame_legacy.c
+++ b/src/game/savegame_legacy.c
@@ -453,24 +453,21 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         game_info->start[i].lara_hitpoints = LARA_HITPOINTS;
     }
 
-    Savegame_Legacy_Read(
-        &game_info->current[g_CurrentLevel].stats.timer, sizeof(uint32_t));
-    Savegame_Legacy_Read(
-        &game_info->current[g_CurrentLevel].stats.kill_count, sizeof(uint32_t));
-    Savegame_Legacy_Read(
-        &game_info->current[g_CurrentLevel].stats.secret_flags,
-        sizeof(uint16_t));
+    uint32_t temp_timer = 0;
+    uint32_t temp_kill_count = 0;
+    uint16_t temp_secret_flags = 0;
+    Savegame_Legacy_Read(&temp_timer, sizeof(uint32_t));
+    Savegame_Legacy_Read(&temp_kill_count, sizeof(uint32_t));
+    Savegame_Legacy_Read(&temp_secret_flags, sizeof(uint16_t));
     Savegame_Legacy_Read(&g_CurrentLevel, sizeof(uint16_t));
+    game_info->current[g_CurrentLevel].stats.timer = temp_timer;
+    game_info->current[g_CurrentLevel].stats.kill_count = temp_kill_count;
+    game_info->current[g_CurrentLevel].stats.secret_flags = temp_secret_flags;
     Savegame_Legacy_Read(
         &game_info->current[g_CurrentLevel].stats.pickup_count,
         sizeof(uint8_t));
-
     Savegame_Legacy_Read(&game_info->bonus_flag, sizeof(uint8_t));
 
-    Savegame_Legacy_SetCurrentPosition(g_CurrentLevel);
-    for (int i = 0; i < g_GameFlow.level_count; i++) {
-        Savegame_ResetCurrentInfo(i);
-    }
     game_info->death_counter_supported = false;
 
     InitialiseLaraInventory(g_CurrentLevel);

--- a/src/game/savegame_legacy.c
+++ b/src/game/savegame_legacy.c
@@ -47,6 +47,7 @@ static void Savegame_Legacy_Read(void *pointer, int size);
 static void Savegame_Legacy_ReadArm(LARA_ARM *arm);
 static void Savegame_Legacy_ReadLara(LARA_INFO *lara);
 static void Savegame_Legacy_ReadLOT(LOT_INFO *lot);
+static void Savegame_Legacy_SetCurrentPosition(int level_num);
 
 static void Savegame_Legacy_Write(void *pointer, int size);
 static void Savegame_Legacy_WriteArm(LARA_ARM *arm);
@@ -352,6 +353,15 @@ static void Savegame_Legacy_ReadLOT(LOT_INFO *lot)
     Savegame_Legacy_Read(&lot->target, sizeof(PHD_VECTOR));
 }
 
+static void Savegame_Legacy_SetCurrentPosition(int level_num)
+{
+    for (int i = 0; i < g_GameFlow.level_count; i++) {
+        if (g_GameFlow.levels[i].level_type == GFL_CURRENT) {
+            g_GameInfo.current[g_CurrentLevel] = g_GameInfo.current[i];
+        }
+    }
+}
+
 char *Savegame_Legacy_GetSaveFileName(int32_t slot)
 {
     size_t out_size =
@@ -457,7 +467,7 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
 
     Savegame_Legacy_Read(&game_info->bonus_flag, sizeof(uint8_t));
 
-    Savegame_SetCurrentPosition(g_CurrentLevel);
+    Savegame_Legacy_SetCurrentPosition(g_CurrentLevel);
     for (int i = 0; i < g_GameFlow.level_count; i++) {
         Savegame_ResetCurrentInfo(i);
     }

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -105,7 +105,7 @@ bool InitialiseLevel(int32_t level_num)
     }
 
     if (g_Lara.item_number != NO_ITEM) {
-        InitialiseLara();
+        InitialiseLara(level_num);
     }
 
     g_Effects = GameBuf_Alloc(NUM_EFFECTS * sizeof(FX_INFO), GBUF_EFFECTS);

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -152,11 +152,11 @@ void InitialiseLevelFlags(void)
     // loading a save can override it to false
     g_GameInfo.death_counter_supported = true;
 
-    g_GameInfo.stats.timer = 0;
-    g_GameInfo.stats.secret_flags = 0;
-    g_GameInfo.stats.pickup_count = 0;
-    g_GameInfo.stats.kill_count = 0;
-    g_GameInfo.stats.death_count = 0;
+    g_GameInfo.current[g_CurrentLevel].stats.timer = 0;
+    g_GameInfo.current[g_CurrentLevel].stats.secret_flags = 0;
+    g_GameInfo.current[g_CurrentLevel].stats.pickup_count = 0;
+    g_GameInfo.current[g_CurrentLevel].stats.kill_count = 0;
+    g_GameInfo.current[g_CurrentLevel].stats.death_count = 0;
 }
 
 void BaddyObjects(void)

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -153,7 +153,7 @@ void Shell_Main(void)
         return;
     }
 
-    Savegame_InitStartEndInfo();
+    Savegame_InitStartCurrentInfo();
     Savegame_ScanSavedGames();
     Settings_Read();
 

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -185,6 +185,11 @@ void Shell_Main(void)
             break;
         }
 
+        case GF_RESTART_GAME: {
+            gf_option = GameFlow_InterpretSequence(gf_param, GFL_RESTART);
+            break;
+        }
+
         case GF_START_CINE:
             gf_option = GameFlow_InterpretSequence(gf_param, GFL_CUTSCENE);
             break;

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -263,7 +263,7 @@ void Stats_Show(int32_t level_num)
     char time_str[100];
     TEXTSTRING *txt;
 
-    const GAME_STATS *stats = &g_GameInfo.end[level_num].stats;
+    const GAME_STATS *stats = &g_GameInfo.current[level_num].stats;
 
     Text_RemoveAll();
 
@@ -388,7 +388,7 @@ void Stats_ShowTotal(const char *filename)
     int16_t secret_flags = 0;
 
     for (int i = 0; i < g_GameFlow.level_count; i++) {
-        const GAME_STATS *stats = &g_GameInfo.end[i].stats;
+        const GAME_STATS *stats = &g_GameInfo.current[i].stats;
 
         total_timer += stats->timer;
         total_death_count += stats->death_count;

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -378,27 +378,25 @@ void Stats_ShowTotal(const char *filename)
     uint32_t total_timer = 0;
     uint32_t total_death_count = 0;
     uint32_t total_kill_count = 0;
-    uint16_t total_secret_flags = 0;
+    uint16_t total_secret_count = 0;
     uint16_t total_pickup_count = 0;
     uint32_t total_max_kill_count = 0;
     uint16_t total_max_secret_count = 0;
     uint16_t total_max_pickup_count = 0;
 
-    int secret_count = 0;
     int16_t secret_flags = 0;
 
-    for (int i = 0; i < g_GameFlow.level_count; i++) {
+    for (int i = g_GameFlow.first_level_num; i <= g_GameFlow.last_level_num;
+         i++) {
         const GAME_STATS *stats = &g_GameInfo.current[i].stats;
 
         total_timer += stats->timer;
         total_death_count += stats->death_count;
         total_kill_count += stats->kill_count;
-        total_secret_flags += stats->secret_flags;
-        secret_count = 0;
         secret_flags = stats->secret_flags;
         for (int j = 0; j < MAX_SECRETS; j++) {
             if (secret_flags & 1) {
-                secret_count++;
+                total_secret_count++;
             }
             secret_flags >>= 1;
         }
@@ -451,7 +449,7 @@ void Stats_ShowTotal(const char *filename)
 
     // secrets
     sprintf(
-        buf, g_GameFlow.strings[GS_STATS_SECRETS_FMT], secret_count,
+        buf, g_GameFlow.strings[GS_STATS_SECRETS_FMT], total_secret_count,
         total_max_secret_count);
     txt = Text_Create(0, y, buf);
     Text_CentreH(txt, 1);

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -976,6 +976,7 @@ typedef enum GAMEFLOW_LEVEL_TYPE {
     GFL_CUTSCENE = 4,
     GFL_GYM = 5,
     GFL_CURRENT = 6, // legacy level type for reading TombATI's savegames
+    GFL_RESTART = 7,
 } GAMEFLOW_LEVEL_TYPE;
 
 typedef enum GAMEFLOW_OPTION {
@@ -989,6 +990,7 @@ typedef enum GAMEFLOW_OPTION {
     GF_LEVEL_COMPLETE = 5 << 6,
     GF_EXIT_GAME = 6 << 6,
     GF_START_SAVED_GAME = 7 << 6,
+    GF_RESTART_GAME = 8 << 6,
 } GAMEFLOW_OPTION;
 
 typedef enum GAMEFLOW_SEQUENCE_TYPE {
@@ -1515,6 +1517,7 @@ typedef struct GAME_INFO {
     uint8_t bonus_flag;
     int32_t current_save_slot;
     bool death_counter_supported;
+    GAMEFLOW_LEVEL_TYPE level_type;
 } GAME_INFO;
 
 typedef struct CREATURE_INFO {

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1484,7 +1484,7 @@ typedef struct GAME_STATS {
     uint8_t max_pickup_count;
 } GAME_STATS;
 
-typedef struct START_INFO {
+typedef struct RESUME_INFO {
     int32_t lara_hitpoints;
     uint16_t pistol_ammo;
     uint16_t magnum_ammo;
@@ -1506,16 +1506,12 @@ typedef struct START_INFO {
             uint16_t costume : 1;
         };
     } flags;
-} START_INFO;
-
-typedef struct END_INFO {
     GAME_STATS stats;
-} END_INFO;
+} RESUME_INFO;
 
 typedef struct GAME_INFO {
-    START_INFO *start;
-    END_INFO *end;
-    GAME_STATS stats; // always for current level
+    RESUME_INFO *start;
+    RESUME_INFO *current;
     uint8_t bonus_flag;
     int32_t current_save_slot;
     bool death_counter_supported;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1517,7 +1517,7 @@ typedef struct GAME_INFO {
     uint8_t bonus_flag;
     int32_t current_save_slot;
     bool death_counter_supported;
-    GAMEFLOW_LEVEL_TYPE level_type;
+    GAMEFLOW_LEVEL_TYPE current_level_type;
 } GAME_INFO;
 
 typedef struct CREATURE_INFO {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes

#### Description

...
I'm aware this is not done and does not solve legacy saving/loading. I just wanted to ask you to look over this to confirm this is the correct direction for the data types.

`GAME_STATS` is now in `RESUME_INFO`. `GAME_INFO` now has `RESUME_INFO *start` and `RESUME_INFO *end`.