### PR TITLE
camera: adhere to naming convention

### DIFF
--- a/src/game/camera.h
+++ b/src/game/camera.h
@@ -4,27 +4,13 @@
 
 #include <stdint.h>
 
-void InitialiseCamera(void);
-void MoveCamera(GAME_VECTOR *ideal, int32_t speed);
-void ClipCamera(
-    int32_t *x, int32_t *y, int32_t target_x, int32_t target_y, int32_t left,
-    int32_t top, int32_t right, int32_t bottom);
-void ShiftCamera(
-    int32_t *x, int32_t *y, int32_t target_x, int32_t target_y, int32_t left,
-    int32_t top, int32_t right, int32_t bottom);
-int32_t BadPosition(int32_t x, int32_t y, int32_t z, int16_t room_num);
-void SmartShift(
-    GAME_VECTOR *ideal,
-    void (*shift)(
-        int32_t *x, int32_t *y, int32_t target_x, int32_t target_y,
-        int32_t left, int32_t top, int32_t right, int32_t bottom));
-void ChaseCamera(ITEM_INFO *item);
-int32_t ShiftClamp(GAME_VECTOR *pos, int32_t clamp);
-void CombatCamera(ITEM_INFO *item);
-void LookCamera(ITEM_INFO *item);
-void FixedCamera(void);
-void CalculateCamera(void);
+void Camera_Initialise(void);
+void Camera_Chase(ITEM_INFO *item);
+void Camera_Combat(ITEM_INFO *item);
+void Camera_Look(ITEM_INFO *item);
+void Camera_Fixed(void);
+void Camera_Update(void);
 
-void CameraOffsetAdditionalAngle(int16_t delta);
-void CameraOffsetAdditionalElevation(int16_t delta);
-void CameraOffsetReset(void);
+void Camera_OffsetAdditionalAngle(int16_t delta);
+void Camera_OffsetAdditionalElevation(int16_t delta);
+void Camera_OffsetReset(void);

--- a/src/game/control.c
+++ b/src/game/control.c
@@ -303,7 +303,7 @@ int32_t ControlPhase(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
         LaraControl(0);
         HairControl(0);
 
-        CalculateCamera();
+        Camera_Update();
         Sound_UpdateEffects();
         g_GameInfo.stats.timer++;
         Overlay_BarHealthTimerTick();

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -86,7 +86,7 @@ int32_t StopGame(void)
 int32_t GameLoop(GAMEFLOW_LEVEL_TYPE level_type)
 {
     g_OverlayFlag = 1;
-    InitialiseCamera();
+    Camera_Initialise();
 
     Stats_CalculateStats();
     g_GameInfo.stats.max_pickup_count = Stats_GetPickups();

--- a/src/game/laramisc.c
+++ b/src/game/laramisc.c
@@ -183,17 +183,17 @@ void LaraControl(int16_t item_num)
     int16_t camera_move_delta = PHD_45 / 30;
 
     if (g_Input.camera_left) {
-        CameraOffsetAdditionalAngle(camera_move_delta);
+        Camera_OffsetAdditionalAngle(camera_move_delta);
     } else if (g_Input.camera_right) {
-        CameraOffsetAdditionalAngle(-camera_move_delta);
+        Camera_OffsetAdditionalAngle(-camera_move_delta);
     }
     if (g_Input.camera_up) {
-        CameraOffsetAdditionalElevation(-camera_move_delta);
+        Camera_OffsetAdditionalElevation(-camera_move_delta);
     } else if (g_Input.camera_down) {
-        CameraOffsetAdditionalElevation(camera_move_delta);
+        Camera_OffsetAdditionalElevation(camera_move_delta);
     }
     if (g_Input.camera_reset) {
-        CameraOffsetReset();
+        Camera_OffsetReset();
     }
 
     switch (g_Lara.water_status) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] ~~I have added a changelog entry about what my pull request accomplishes~~ Internal change

#### Descripton

Old name                          | New Name                           | Other changes
---                               | ---                                | ---
`InitialiseCamera`                | `Camera_Initialise`                |
`ChaseCamera`                     | `Camera_Chase`                     |
`CombatCamera`                    | `Camera_Combat`                    |
`LookCamera`                      | `Camera_Look`                      |
`FixedCamera`                     | `Camera_Fixed`                     |
`CalculateCamera`                    | `Camera_Update`                    |
`CameraOffsetAdditionalAngle`     | `Camera_OffsetAdditionalAngle`     |
`CameraOffsetAdditionalElevation` | `Camera_OffsetAdditionalElevation` |
`CameraOffsetReset`               | `Camera_OffsetReset`               |
`BadPosition`                     | `Camera_BadPosition`               | Made private; changed return type to bool
`ShiftClamp`                      | `Camera_ShiftClamp`                | Made private
`SmartShift`                      | `Camera_SmartShift`                | Made private
`ClipCamera`                      | `Camera_Clip`                      | Made private
`ShiftCamera`                     | `Camera_Shift`                     | Made private
`MoveCamera`                      | `Camera_Move`                      | Made private