### PR TITLE
Ability to decide whether active or newly triggered (runaway) Pierre is despawned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - added a cheat to increase the game speed (#135)
 - added a matrix stack overflow error check and message if GetRoomBounds runs infinitely (#506)
 - added ability to turn off trex collision (#437)
-- added the ability to make new Pierre replace an old active (runaway) Pierre
+- added the ability to make freshly triggered (runaway) Pierre replace an already existing (runaway) Pierre (#532)
 - fixed ghost margins during fade animation on HiDPI screens (#438)
 - fixed music rolling over to the main menu if main menu music disabled (#490)
 - fixed Unfinished Business gameflow not using basic / detailed stats strings (#497, regression from 2.7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added a cheat to increase the game speed (#135)
 - added a matrix stack overflow error check and message if GetRoomBounds runs infinitely (#506)
 - added ability to turn off trex collision (#437)
+- added the ability to make new Pierre replace an old active (runaway) Pierre
 - fixed ghost margins during fade animation on HiDPI screens (#438)
 - fixed music rolling over to the main menu if main menu music disabled (#490)
 - fixed Unfinished Business gameflow not using basic / detailed stats strings (#497, regression from 2.7)

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Not all options are turned on by default. Refer to `Tomb1Main.json5` for details
 - added fade effects to displayed images
 - added unobtainable pickups and kills stats support in the gameflow
 - added the option to pause sound in the inventory screen
+- added the ability to make freshly triggered (runaway) Pierre replace an already existing (runaway) Pierre
 - changed internal game memory limit from 3.5 MB to 16 MB
 - changed moveable limit from 256 to 10240
 - changed maximum textures from 2048 to 8192

--- a/bin/cfg/Tomb1Main.json5
+++ b/bin/cfg/Tomb1Main.json5
@@ -163,6 +163,9 @@
     // Fixes alligators dealing no damage if Lara remains still in the water
     "fix_alligator_ai": true,
 
+    // Make freshly triggered (runaway) Pierre replace an already existing (runaway) Pierre
+    "change_pierre_spawn": true,
+
     // The desired field of view in degrees, which overrides the hardcoded
     // default. The default values are 80 (horizontal) and 65 (vertical).
     "fov_value": 65,

--- a/src/config.c
+++ b/src/config.c
@@ -149,6 +149,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(fix_bridge_collision, true);
     READ_BOOL(fix_qwop_glitch, false);
     READ_BOOL(fix_alligator_ai, true);
+    READ_BOOL(fix_pierre_spawn, true);
     READ_INTEGER(fov_value, 65);
     READ_INTEGER(resolution_width, -1);
     READ_INTEGER(resolution_height, -1);

--- a/src/config.c
+++ b/src/config.c
@@ -149,7 +149,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(fix_bridge_collision, true);
     READ_BOOL(fix_qwop_glitch, false);
     READ_BOOL(fix_alligator_ai, true);
-    READ_BOOL(fix_pierre_spawn, true);
+    READ_BOOL(change_pierre_spawn, true);
     READ_INTEGER(fov_value, 65);
     READ_INTEGER(resolution_width, -1);
     READ_INTEGER(resolution_height, -1);

--- a/src/config.h
+++ b/src/config.h
@@ -74,6 +74,7 @@ typedef struct {
     bool fix_bridge_collision;
     bool fix_qwop_glitch;
     bool fix_alligator_ai;
+    bool fix_pierre_spawn;
     int32_t fov_value;
     bool fov_vertical;
     bool disable_demo;

--- a/src/config.h
+++ b/src/config.h
@@ -74,7 +74,7 @@ typedef struct {
     bool fix_bridge_collision;
     bool fix_qwop_glitch;
     bool fix_alligator_ai;
-    bool fix_pierre_spawn;
+    bool change_pierre_spawn;
     int32_t fov_value;
     bool fov_vertical;
     bool disable_demo;

--- a/src/game/objects/ai/pierre.c
+++ b/src/game/objects/ai/pierre.c
@@ -1,5 +1,6 @@
 #include "game/objects/ai/pierre.h"
 
+#include "config.h"
 #include "game/box.h"
 #include "game/collide.h"
 #include "game/control.h"
@@ -62,13 +63,30 @@ void Pierre_Control(int16_t item_num)
 {
     ITEM_INFO *item = &g_Items[item_num];
 
-    if (m_PierreItemNum == NO_ITEM) {
-        m_PierreItemNum = item_num;
-    } else if (m_PierreItemNum != item_num) {
-        if (item->flags & IF_ONESHOT) {
-            KillItem(m_PierreItemNum);
-        } else {
-            KillItem(item_num);
+    if (g_Config.fix_pierre_spawn) {
+        if (m_PierreItemNum == NO_ITEM) {
+            m_PierreItemNum = item_num;
+        } else if (m_PierreItemNum != item_num) {
+            ITEM_INFO *old_pierre = &g_Items[m_PierreItemNum];
+            if (old_pierre->flags & IF_ONESHOT) {
+                if (!(item->flags & IF_ONESHOT)) {
+                    KillItem(item_num);
+                }
+            } else {
+                KillItem(m_PierreItemNum);
+                m_PierreItemNum = item_num;
+            }
+        }
+    } else {
+
+        if (m_PierreItemNum == NO_ITEM) {
+            m_PierreItemNum = item_num;
+        } else if (m_PierreItemNum != item_num) {
+            if (item->flags & IF_ONESHOT) {
+                KillItem(m_PierreItemNum);
+            } else {
+                KillItem(item_num);
+            }
         }
     }
 

--- a/src/game/objects/ai/pierre.c
+++ b/src/game/objects/ai/pierre.c
@@ -63,7 +63,7 @@ void Pierre_Control(int16_t item_num)
 {
     ITEM_INFO *item = &g_Items[item_num];
 
-    if (g_Config.fix_pierre_spawn) {
+    if (g_Config.change_pierre_spawn) {
         if (m_PierreItemNum == NO_ITEM) {
             m_PierreItemNum = item_num;
         } else if (m_PierreItemNum != item_num) {
@@ -78,7 +78,6 @@ void Pierre_Control(int16_t item_num)
             }
         }
     } else {
-
         if (m_PierreItemNum == NO_ITEM) {
             m_PierreItemNum = item_num;
         } else if (m_PierreItemNum != item_num) {


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

If there is a runaway Pierre active and the player tries to trigger another runaway Pierre, the new Pierre will be despawned immediately while the old one remains. **With this change**, the player can change this behaviour so that old Pierre will be despawned and new Pierre remains. This way the player gets to face all instances of Pierre even if they did not make the old Pierre run before trying to trigger a new one.
...
