### PR TITLE
savegame: changed savegame requestor to remember requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added a cheat to increase the game speed (#135)
 - added a matrix stack overflow error check and message if GetRoomBounds runs infinitely (#506)
 - added ability to turn off trex collision (#437)
+- changed savegame requestor to remember the user's requested slot number (#514)
 - fixed ghost margins during fade animation on HiDPI screens (#438)
 - fixed music rolling over to the main menu if main menu music disabled (#490)
 - fixed Unfinished Business gameflow not using basic / detailed stats strings (#497, regression from 2.7)

--- a/src/game/savegame.c
+++ b/src/game/savegame.c
@@ -506,10 +506,6 @@ void Savegame_ScanSavedGames(void)
             sprintf(
                 &req->item_texts[req->items * req->item_text_len], "%s %d",
                 savegame_info->level_title, savegame_info->counter);
-
-            if (savegame_info->counter == g_SaveCounter) {
-                req->requested = i;
-            }
         } else {
             req->item_flags[req->items] |= RIF_BLOCKED;
             sprintf(


### PR DESCRIPTION
Resolves #514.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Changed the savegame requestor to remember the user's requested slot number. The requestor no longer highlights the newest savegame slot every time the load game menu is open.

Video: https://streamable.com/wmh6l3
...
