### PR TITLE
savegame: fix pushables loading for legacy savegames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/2.8...master)
 - fixed Pierre not resetting across levels (#538, regression from 2.7)
+- fixed pushables breaking with flipped rooms when loading a save (#536, regression from 2.8)
 
 ## [2.8](https://github.com/rr-/Tomb1Main/compare/2.7...2.8) - 2022-05-04
 - added the option to pause sound in the inventory screen (#309)

--- a/src/game/savegame_legacy.c
+++ b/src/game/savegame_legacy.c
@@ -102,8 +102,6 @@ static bool Savegame_Legacy_NeedsBaconLaraFix(char *buffer)
     Savegame_Legacy_Skip(MAX_FLIP_MAPS * sizeof(int8_t)); // flipmap table
     Savegame_Legacy_Skip(g_NumberCameras * sizeof(int16_t)); // cameras
 
-    Savegame_PreprocessItems();
-
     for (int i = 0; i < g_LevelItemCount; i++) {
         ITEM_INFO *item = &g_Items[i];
         OBJECT_INFO *obj = &g_Objects[item->object_number];
@@ -510,6 +508,8 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     for (int i = 0; i < g_NumberCameras; i++) {
         Savegame_Legacy_Read(&g_Camera.fixed[i].flags, sizeof(int16_t));
     }
+
+    Savegame_PreprocessItems();
 
     for (int i = 0; i < g_LevelItemCount; i++) {
         ITEM_INFO *item = &g_Items[i];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #536
